### PR TITLE
Fix error when initializing database

### DIFF
--- a/beats.cfg.sample
+++ b/beats.cfg.sample
@@ -12,3 +12,6 @@ password = replace_me
 
 [Database]
 url = mysql://root@localhost/acoustics2
+
+[Artwork]
+art_path = replace_me


### PR DESCRIPTION
When running db.py for the first time, you get:

Traceback (most recent call last):
  File "db.py", line 7, in <module>
    import art
  File "/home/rohan/Projects/beats/art.py", line 8, in <module>
    ART_DIR = config.get('Artwork', 'art_path')
  File "/usr/lib/python2.7/ConfigParser.py", line 330, in get
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'Artwork'

Add the proper section to beats.cfg.sample

Signed-off-by: Rohan Mathur <rohan@rmathur.com>