### PR TITLE
Equalizer support + improved playback shuffle

### DIFF
--- a/art.py
+++ b/art.py
@@ -31,7 +31,7 @@ def index_art(song):
             if tag.startswith('APIC'):
                 data = tags[tag].data
                 break
-    elif isinstance(tags, MP4Tags) and tags['covr']:
+    elif isinstance(tags, MP4Tags) and 'covr' in tags.keys() and tags['covr']:
         data = tags['covr'][0]
 
     if not data:

--- a/beats.cfg.sample
+++ b/beats.cfg.sample
@@ -1,5 +1,7 @@
 [Player]
 player_name = 1104
+dont_repeat_for = 0.5
+max_dont_repeat_for = 100
 
 [Authentication]
 enabled = true

--- a/main.py
+++ b/main.py
@@ -35,6 +35,16 @@ def login_required(f):
     return decorated_function
 
 
+def check_eq_support(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not player.equalizer_supported:
+            return jsonify({'message': 'Equalizer not supported'}), 400
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
 @app.errorhandler(404)
 def not_found(error):
     return jsonify({'message': str(error)}), 404
@@ -81,6 +91,7 @@ def player_get_equalizer_info():
 
 
 @app.route('/v1/player/enable_eq', methods=['POST'])
+@check_eq_support
 @login_required
 @crossdomain(origin='*')
 def player_enable_eq():
@@ -91,6 +102,7 @@ def player_enable_eq():
 
 
 @app.route('/v1/player/adjust_eq_preset', methods=['POST'])
+@check_eq_support
 @login_required
 @crossdomain(origin='*')
 def player_adjust_eq_preset():
@@ -107,6 +119,7 @@ def player_adjust_eq_preset():
 
 
 @app.route('/v1/player/adjust_eq_preamp', methods=['POST'])
+@check_eq_support
 @login_required
 @crossdomain(origin='*')
 def player_adjust_eq_preamp():
@@ -122,6 +135,7 @@ def player_adjust_eq_preamp():
 
 
 @app.route('/v1/player/adjust_eq_band', methods=['POST'])
+@check_eq_support
 @login_required
 @crossdomain(origin='*')
 def player_adjust_eq_band():

--- a/main.py
+++ b/main.py
@@ -74,6 +74,75 @@ def player_set_volume():
     return jsonify({'message': 'No volume parameter'}), 400
 
 
+@app.route('/v1/equalizer_info', methods=['GET'])
+@crossdomain(origin='*')
+def player_get_equalizer_info():
+    return jsonify(player.get_static_equalizer_info())
+
+
+@app.route('/v1/player/enable_eq', methods=['POST'])
+@login_required
+@crossdomain(origin='*')
+def player_enable_eq():
+    if request.form.get('enabled'):
+        enabled = request.form.get('enabled') in ('True', 'true')
+        return jsonify(player.set_equalizer_enabled(enabled))
+    return jsonify({'message': 'No equalizer enablement parameter'}), 400
+
+
+@app.route('/v1/player/adjust_eq_preset', methods=['POST'])
+@login_required
+@crossdomain(origin='*')
+def player_adjust_eq_preset():
+    if request.form.get('index'):
+        idx = int(request.form.get('index'))
+        if 0 <= idx < player.num_equalizer_presets:
+            return jsonify(player.set_equalizer_preset(idx))
+        else:
+            return jsonify({
+                'message': 'Equalizer preset index must be between 0 and %d'%(
+                    player.num_equalizer_presets - 1)
+            }), 400
+    return jsonify({'message': 'No equalizer preset index parameter'}), 400
+
+
+@app.route('/v1/player/adjust_eq_preamp', methods=['POST'])
+@login_required
+@crossdomain(origin='*')
+def player_adjust_eq_preamp():
+    if request.form.get('level'):
+        lvl = float(request.form.get('level'))
+        if -20.0 <= lvl <= 20.0:
+            return jsonify(player.set_equalizer_preamp(lvl))
+        else:
+            return jsonify({'message':
+                'Equalizer preamp level must be between -20 dB and +20 dB'
+            }), 400
+    return jsonify({'message': 'No equalizer preamp level parameter'}), 400
+
+
+@app.route('/v1/player/adjust_eq_band', methods=['POST'])
+@login_required
+@crossdomain(origin='*')
+def player_adjust_eq_band():
+    if not request.form.get('band'):
+        return jsonify({'message': 'No band index parameter'}), 400
+    if not request.form.get('level'):
+        return jsonify({'message': 'No band level parameter'}), 400
+    idx = int(request.form.get('band'))
+    lvl = float(request.form.get('level'))
+    if idx < 0 or idx >= player.num_equalizer_bands:
+        return jsonify({
+            'message': 'Equalizer band index must be between 0 and %d'%(
+                player.num_equalizer_bands - 1)
+        }), 400
+    if lvl < -20.0 or lvl > 20.0:
+        return jsonify({
+            'message': 'Equalizer band level must be between -20 dB and +20 dB'
+        }), 400
+    return jsonify(player.set_equalizer_band(idx, lvl))
+
+
 @app.route('/v1/songs/<song_id>', methods=['GET'])
 @crossdomain(origin='*')
 def show_song(song_id):

--- a/player.py
+++ b/player.py
@@ -150,7 +150,7 @@ def set_equalizer_preset(idx):
 
 def set_equalizer_preamp(lev):
     global equalizer_preamp_level
-    equalizer_preamp_level = float(lev)
+    equalizer_preamp_level = lev
     vlc.libvlc_audio_equalizer_set_preamp(equalizer, lev)
     if equalizer_enabled:
         player.set_equalizer(equalizer)
@@ -159,7 +159,7 @@ def set_equalizer_preamp(lev):
 
 def set_equalizer_band(idx, lev):
     global equalizer_band_levels
-    equalizer_band_levels[idx] = float(lev)
+    equalizer_band_levels[idx] = lev
     vlc.libvlc_audio_equalizer_set_amp_at_index(equalizer, lev, idx)
     if equalizer_enabled:
         player.set_equalizer(equalizer)

--- a/player.py
+++ b/player.py
@@ -140,12 +140,11 @@ def set_equalizer_enabled(enabled):
 
 def set_equalizer_preset(idx):
     global equalizer
-    if idx in xrange(num_equalizer_presets):
-        vlc.libvlc_audio_equalizer_release(equalizer)
-        equalizer = vlc.libvlc_audio_equalizer_new_from_preset(idx)
-        populate_equalizer_globals(equalizer, preset_idx=idx)
-        if equalizer_enabled:
-            player.set_equalizer(equalizer)
+    vlc.libvlc_audio_equalizer_release(equalizer)
+    equalizer = vlc.libvlc_audio_equalizer_new_from_preset(idx)
+    populate_equalizer_globals(equalizer, preset_idx=idx)
+    if equalizer_enabled:
+        player.set_equalizer(equalizer)
     return get_status()
 
 
@@ -160,11 +159,10 @@ def set_equalizer_preamp(lev):
 
 def set_equalizer_band(idx, lev):
     global equalizer_band_levels
-    if idx in xrange(num_equalizer_bands):
-        equalizer_band_levels[idx] = float(lev)
-        vlc.libvlc_audio_equalizer_set_amp_at_index(equalizer, lev, idx)
-        if equalizer_enabled:
-            player.set_equalizer(equalizer)
+    equalizer_band_levels[idx] = float(lev)
+    vlc.libvlc_audio_equalizer_set_amp_at_index(equalizer, lev, idx)
+    if equalizer_enabled:
+        player.set_equalizer(equalizer)
     return get_status()
 
 

--- a/player.py
+++ b/player.py
@@ -28,24 +28,33 @@ def populate_equalizer_globals(equalizer, preset_idx=0):
         vlc.libvlc_audio_equalizer_get_amp_at_index(equalizer, idx)
         for idx in xrange(num_equalizer_bands)]
 
-# Initialize equalizer
-equalizer = vlc.libvlc_audio_equalizer_new()
-equalizer_enabled = False
+try:
+    # Initialize equalizer
+    equalizer = vlc.libvlc_audio_equalizer_new()
+    equalizer_enabled = False
 
-# Populate equalizer band frequencies (values in Hz)
-num_equalizer_bands = vlc.libvlc_audio_equalizer_get_band_count()
-equalizer_band_freqs = tuple(
-    vlc.libvlc_audio_equalizer_get_band_frequency(idx)
-    for idx in xrange(num_equalizer_bands))
+    # Populate equalizer band frequencies (values in Hz)
+    num_equalizer_bands = vlc.libvlc_audio_equalizer_get_band_count()
+    equalizer_band_freqs = tuple(
+        vlc.libvlc_audio_equalizer_get_band_frequency(idx)
+        for idx in xrange(num_equalizer_bands))
 
-# Populate equalizer preset names
-num_equalizer_presets = vlc.libvlc_audio_equalizer_get_preset_count()
-equalizer_preset_names = tuple(
-    vlc.libvlc_audio_equalizer_get_preset_name(idx)
-    for idx in xrange(num_equalizer_presets))
+    # Populate equalizer preset names
+    num_equalizer_presets = vlc.libvlc_audio_equalizer_get_preset_count()
+    equalizer_preset_names = tuple(
+        vlc.libvlc_audio_equalizer_get_preset_name(idx)
+        for idx in xrange(num_equalizer_presets))
 
-# Initialize equalizer globals
-populate_equalizer_globals(equalizer)
+    # Initialize equalizer globals
+    populate_equalizer_globals(equalizer)
+
+    # If we get to this stage, we know we have a version of VLC that has
+    # equalizer support
+    equalizer_supported = True
+except NameError:
+    # If we reach this exception, we know we have an older version of VLC that
+    # does not have equalizer support
+    equalizer_supported = False
 
 def play(mrl):
     m = instance.media_new(mrl)
@@ -84,11 +93,12 @@ def stop():
 
 def get_status():
     media = player.get_media()
-    status = {'state': str(player.get_state()), 'volume': volume,
-              'equalizer_enabled': equalizer_enabled,
-              'equalizer_preset': equalizer_preset,
-              'equalizer_preamp_level': equalizer_preamp_level,
-              'equalizer_band_levels': equalizer_band_levels}
+    status = {'state': str(player.get_state()), 'volume': volume}
+    if equalizer_supported:
+        status['equalizer_enabled'] = equalizer_enabled
+        status['equalizer_preset'] = equalizer_preset
+        status['equalizer_preamp_level'] = equalizer_preamp_level
+        status['equalizer_band_levels'] = equalizer_band_levels
     if media:
         status['media'] = vlc.bytes_to_str(media.get_mrl())
         status['current_time'] = player.get_time()
@@ -113,8 +123,11 @@ def set_volume(vol):
 def get_static_equalizer_info():
     # This routine is useful in that we know right away the number of presets
     # and the number of bands
-    return {'equalizer_preset_names': equalizer_preset_names,
-            'equalizer_band_freqs': equalizer_band_freqs}
+    info = {'equalizer_supported': equalizer_supported}
+    if equalizer_supported:
+        info['equalizer_preset_names'] = equalizer_preset_names
+        info['equalizer_band_freqs'] = equalizer_band_freqs
+    return info
 
 
 def set_equalizer_enabled(enabled):

--- a/static/beats.css
+++ b/static/beats.css
@@ -60,7 +60,7 @@ html, body {
     padding: 8px;
     text-shadow: 1px 1px 1px black; }
   .dialog-area .confirm {
-    background-color: #448aa6; }
+    background-color: #448AA6; }
   .dialog-area .cancel {
     background-color: #d44637; }
 
@@ -75,7 +75,7 @@ html, body {
 
 .top-area {
   align-items: center;
-  background: linear-gradient(to bottom, #383838 0%, #222222 100%);
+  background: linear-gradient(to bottom, #383838 0%, #222 100%);
   border-bottom: 1px solid #333;
   display: flex;
   flex: 1;
@@ -98,7 +98,7 @@ html, body {
   width: 100%; }
 
 .side-area {
-  background: linear-gradient(to bottom, #444444 0%, #333333 100%);
+  background: linear-gradient(to bottom, #444 0%, #333 100%);
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -130,9 +130,9 @@ html, body {
     padding-top: 4px;
     position: relative; }
     .playlists li:hover {
-      background: #448aa6; }
+      background: #448AA6; }
     .playlists li.dragover {
-      background: #448aa6; }
+      background: #448AA6; }
 
 .playlist-area {
   background-color: #444;
@@ -172,7 +172,7 @@ html, body {
       width: 150px;
       text-shadow: 1px 1px 1px black; }
     .albumgrid-area li:hover {
-      background: #448aa6;
+      background: #448AA6;
       box-shadow: 0 0 10px 0 black; }
 
 table.playlist {
@@ -184,7 +184,7 @@ table.playlist {
   table-layout: fixed;
   width: 100%; }
   table.playlist thead {
-    background: linear-gradient(to bottom, #448aa6 0%, #356b8c 100%); }
+    background: linear-gradient(to bottom, #448AA6 0%, #356B8C 100%); }
   table.playlist th {
     padding: 4px;
     border-right: 1px solid black; }
@@ -258,7 +258,7 @@ table.playlist {
 
 .bottom-area {
   align-items: center;
-  background: linear-gradient(to bottom, #444444 0%, #333333 100%);
+  background: linear-gradient(to bottom, #444 0%, #333 100%);
   border-top: 1px solid #333;
   box-shadow: 0 0 17px 3px black;
   display: flex;
@@ -270,6 +270,32 @@ table.playlist {
   vertical-align: middle;
   width: 100%;
   z-index: 5; }
+
+.equalizer.row-container {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  vertical-align: middle;
+  margin: 20px; }
+  .equalizer.row-container.right-aligned {
+    align-items: flex-end; }
+.equalizer.row-filler {
+  width: 100%; }
+.equalizer.preset.label {
+  margin-left: 20px;
+  margin-right: 10px; }
+.equalizer.preset.selector {
+  width: 100px; }
+.equalizer.preamp.label {
+  width: 120px; }
+  .equalizer.preamp.label.db {
+    text-align: right; }
+.equalizer.band.ctrl-area {
+  text-align: center;
+  width: 65px; }
+.equalizer.band.label {
+  margin-top: 15px; }
 
 .control {
   color: #D0D9E5;
@@ -284,7 +310,7 @@ table.playlist {
     text-shadow: 1px 1px 1px black;
     transition: text-shadow 0.2s, box-shadow 0.2s; }
     .control.button:hover {
-      text-shadow: 0 0 4px #d0d9e5; }
+      text-shadow: 0 0 4px #D0D9E5; }
   .control.rect-button {
     background: #555;
     border-radius: 4px;
@@ -314,20 +340,40 @@ table.playlist {
     .control input:focus {
       outline: none; }
     .control input:hover {
-      box-shadow: 0 0 4px #d0d9e5; }
+      box-shadow: 0 0 4px #D0D9E5; }
   .control.bar {
-    background: linear-gradient(to bottom, #aaaaaa 0%, white 100%);
+    background: linear-gradient(to bottom, #AAA 0%, #FFF 100%);
     border-radius: 5px;
     border: 1px solid #444;
     height: 10px;
     position: relative; }
+    .control.bar.as-vertical {
+      height: none;
+      width: 10px; }
+    .control.bar.as-toggle {
+      height: 18px; }
+      .control.bar.as-toggle.as-vertical {
+        height: none;
+        width: 18px; }
     .control.bar:hover {
       box-shadow: 0 0 4px #D0D9E5; }
     .control.bar .cover {
-      background-color: #448aa6;
+      background-color: #448AA6;
       border-radius: 4px;
       height: 10px;
       position: absolute; }
+      .control.bar .cover.as-vertical {
+        height: none;
+        width: 10px; }
+      .control.bar .cover.as-toggle {
+        height: 18px; }
+        .control.bar .cover.as-toggle.as-off {
+          background-color: #900; }
+        .control.bar .cover.as-toggle.as-on {
+          background-color: #360; }
+        .control.bar .cover.as-toggle.as-vertical {
+          height: none;
+          width: 18px; }
     .control.bar .handle {
       background: linear-gradient(to bottom, #7e868c 0%, #374044 100%);
       border-radius: 8px;
@@ -339,12 +385,31 @@ table.playlist {
       position: relative;
       transition: box-shadow 0.1s;
       width: 16px; }
+      .control.bar .handle.as-toggle {
+        background: linear-gradient(to bottom, #AAA 0%, #FFF 100%);
+        border-radius: 2px;
+        margin-top: 0px; }
+      .control.bar .handle.as-vertical {
+        margin-left: -4px;
+        margin-right: -8px; }
       .control.bar .handle:hover {
-        box-shadow: 0 0 4px #d0d9e5; }
+        box-shadow: 0 0 4px #D0D9E5; }
   .control.volume {
     width: 150px; }
+  .control.equalizer-bars {
+    padding-left: 0px;
+    padding-right: 0px;
+    margin: 0 auto; }
+    .control.equalizer-bars.on-off {
+      width: 50px; }
+    .control.equalizer-bars.preamp {
+      width: 100%; }
+    .control.equalizer-bars.band {
+      height: 250px; }
   .control.track {
     width: 100%; }
   .control.current-time-label {
     margin-left: 16px;
     margin-right: 16px; }
+
+/*# sourceMappingURL=beats.css.map */

--- a/static/beats.js
+++ b/static/beats.js
@@ -896,37 +896,41 @@ function($scope, $http, $interval, $cookies)
             {
                 $scope.volume = data['player_status']['volume'];
             }
-            // Prevent enabling/disabling the equalizer while the user is changing it
-            if (!$scope.holdEqEnabledUpdate)
+            // Check for equalizer support
+            if (data['player_status']['equalizer_enabled'] !== undefined)
             {
-                $scope.eqEnabled = data['player_status']['equalizer_enabled'];
-            }
-            // Prevent changing the equalizer preset while the user is changing it
-            if (!$scope.holdEqPresetUpdate)
-            {
-                $scope.eqPresetIndex = data['player_status']['equalizer_preset'];
-            }
-            // Prevent changing the preamp while the user is changing it
-            if (!$scope.holdEqPreampUpdate)
-            {
-                $scope.eqPreampLevel = data['player_status']['equalizer_preamp_level'];
-            }
-            levels = data['player_status']['equalizer_band_levels'];
-            for (var bandIdx = 0; bandIdx < levels.length; bandIdx++)
-            {
-                var holdName = 'holdEqBand' + bandIdx + 'Update';
-                var hold = $scope[holdName];
-                if ($scope[holdName] === undefined)
+                // Prevent enabling/disabling the equalizer while the user is changing it
+                if (!$scope.holdEqEnabledUpdate)
                 {
-                    $scope[holdName] = false;
+                    $scope.eqEnabled = data['player_status']['equalizer_enabled'];
                 }
-                // Prevent changing the band while the user is changing it
-                if (!$scope[holdName])
+                // Prevent changing the equalizer preset while the user is changing it
+                if (!$scope.holdEqPresetUpdate)
                 {
-                    $scope['bandLevel' + bandIdx] = levels[bandIdx];
+                    $scope.eqPresetIndex = data['player_status']['equalizer_preset'];
                 }
+                // Prevent changing the preamp while the user is changing it
+                if (!$scope.holdEqPreampUpdate)
+                {
+                    $scope.eqPreampLevel = data['player_status']['equalizer_preamp_level'];
+                }
+                levels = data['player_status']['equalizer_band_levels'];
+                for (var bandIdx = 0; bandIdx < levels.length; bandIdx++)
+                {
+                    var holdName = 'holdEqBand' + bandIdx + 'Update';
+                    var hold = $scope[holdName];
+                    if ($scope[holdName] === undefined)
+                    {
+                        $scope[holdName] = false;
+                    }
+                    // Prevent changing the band while the user is changing it
+                    if (!$scope[holdName])
+                    {
+                        $scope['bandLevel' + bandIdx] = levels[bandIdx];
+                    }
+                }
+                $scope.updateEqLabels(-2);
             }
-            $scope.updateEqLabels(-2);
             $scope.isPlaying = data['player_status']['state'] == 'State.Playing';
         });
 

--- a/static/beats.js
+++ b/static/beats.js
@@ -421,6 +421,7 @@ function($scope, $http, $interval, $cookies)
     $scope.albumlist = [];
     $scope.queue = [];
     $scope.volume = 0;
+    $scope.eqSupported = false;
     $scope.eqEnabled = false;
     $scope.eqPresets = [];
     $scope.eqPresetIndex = 0;
@@ -783,31 +784,36 @@ function($scope, $http, $interval, $cookies)
         $http.get(backendBase + '/v1/equalizer_info')
         .success(function(data)
         {
-            // Populate preset choices in preset menu
-            var presNames = data['equalizer_preset_names'];
-            for (var presIndex = 0; presIndex < presNames.length; presIndex++)
+            // Check for equalizer support
+            $scope.eqSupported = data['equalizer_supported'];
+            if ($scope.eqSupported)
             {
-                $scope.eqPresets.push({
-                    value: presIndex,
-                    displayName: presNames[presIndex]
-                });
-            }
-            // Add equalizer band controls
-            var freqs = data['equalizer_band_freqs'];
-            for (var bandIndex = 0; bandIndex < freqs.length; bandIndex++)
-            {
-                // Dynamically initialize scope variables for the band control
-                var holdName = 'holdEqBand' + bandIndex + 'Update';
-                if ($scope[holdName] === undefined)
+                // Populate preset choices in preset menu
+                var presNames = data['equalizer_preset_names'];
+                for (var presIndex = 0; presIndex < presNames.length; presIndex++)
                 {
-                    $scope[holdName] = false;
-                    $scope['bandLevel' + bandIndex] = 0.0;
+                    $scope.eqPresets.push({
+                        value: presIndex,
+                        displayName: presNames[presIndex]
+                    });
                 }
-                // Add the frequency along with its corresponding band index
-                $scope.eqBandFrequencies.push({
-                    freq: freqs[bandIndex],
-                    index: bandIndex
-                });
+                // Add equalizer band controls
+                var freqs = data['equalizer_band_freqs'];
+                for (var bandIndex = 0; bandIndex < freqs.length; bandIndex++)
+                {
+                    // Dynamically initialize scope variables for the band control
+                    var holdName = 'holdEqBand' + bandIndex + 'Update';
+                    if ($scope[holdName] === undefined)
+                    {
+                        $scope[holdName] = false;
+                        $scope['bandLevel' + bandIndex] = 0.0;
+                    }
+                    // Add the frequency along with its corresponding band index
+                    $scope.eqBandFrequencies.push({
+                        freq: freqs[bandIndex],
+                        index: bandIndex
+                    });
+                }
             }
         });
     };

--- a/static/beats.js
+++ b/static/beats.js
@@ -407,7 +407,6 @@ function($scope, $http, $interval, $cookies)
     //
 
     var backendBase = '/beats/1104'
-    var backendBase = '';
     var authentication = true;
 
     $scope.showLoginDialog = false;

--- a/static/beats.js
+++ b/static/beats.js
@@ -10,6 +10,13 @@ function containsType(types, name)
     return false;
 }
 
+function roundDbValue(level)
+{
+    var negLevel = level < 0.0;
+    var absLevel = negLevel ? -level : level;
+    return (negLevel ? -0.1 : 0.1) * Math.floor(absLevel * 10.0 + 0.5);
+}
+
 angular.module('Beats.filters', [])
 
 // A filter that takes a number of seconds and converts it to MM:SS format
@@ -23,6 +30,40 @@ angular.module('Beats.filters', [])
             seconds = '0' + seconds;
         }
         return Math.floor(input / 60) + ':' + seconds;
+    };
+})
+
+// A filter that takes a given frequency and converts it into Hz or kHz with
+// the appropriate label
+.filter('freqFormat', function()
+{
+    return function(input)
+    {
+        var unit = 'Hz';
+        var value = input;
+        if (input > 999.5)
+        {
+            unit = 'kHz';
+            value /= 1000.0;
+        }
+        return Math.floor(value + 0.5) + ' ' + unit;
+    };
+})
+
+// A filter that rounds a dB level (the same way as how the rounding is done in
+// roundDbValue) and appends a 'dB' label
+.filter('dbFormat', function()
+{
+    return function(input)
+    {
+        var negInput = input < 0.0;
+        var absInput = negInput ? -input : input;
+
+        var multInput = Math.floor(absInput * 10.0 + 0.5);
+        var tenth = multInput % 10;
+        var whole = Math.floor(multInput / 10);
+
+        return (negInput ? '-' : '') + whole + '.' + tenth + ' dB';
     };
 });
 
@@ -61,6 +102,10 @@ angular.module('BeatsApp', ['Beats.filters', 'ngCookies'])
             // Get the parameters that determine how to set the value
             var barMin = attrs.barMin | 0;
             var barMax = attrs.barMax | 0;
+            var barOrientation = attrs.barOrientation;
+            var barUseParentScope = attrs.barUseParentScope;
+            var useParent = barUseParentScope == 'true';
+            var scopeToUse = useParent ? scope.$parent : scope;
 
             var dragging = false;
 
@@ -72,21 +117,37 @@ angular.module('BeatsApp', ['Beats.filters', 'ngCookies'])
                     event.preventDefault();
 
                     // Determine ratio from 0 to 1 over the control
-                    var ratioX = (event.clientX - element[0].offsetLeft) / (element[0].offsetWidth);
+                    var ratio;
+                    if (barOrientation == 'vertical')
+                    {
+                        ratio = 1.0 - (event.clientY - element[0].offsetTop) / (element[0].offsetHeight);
+                    }
+                    else
+                    {
+                        ratio = (event.clientX - element[0].offsetLeft) / (element[0].offsetWidth);
+                    }
+                    console.log(ratio);
 
                     // Linearly map that ratio to between barMax and barMin
-                    scope[attrs.barControl] = ratioX * (barMax - barMin) + barMin;
-                    if (scope[attrs.barControl] < barMin)
+                    scopeToUse[attrs.barControl] = ratio * (barMax - barMin) + barMin;
+                    if (scopeToUse[attrs.barControl] < barMin)
                     {
-                        scope[attrs.barControl] = barMin;
+                        scopeToUse[attrs.barControl] = barMin;
                     }
-                    if (scope[attrs.barControl] > barMax)
+                    if (scopeToUse[attrs.barControl] > barMax)
                     {
-                        scope[attrs.barControl] = barMax;
+                        scopeToUse[attrs.barControl] = barMax;
+                    }
+
+                    // Mouse move event hooks are optional (WARNING: The
+                    // evaluated expression runs in this scope, never the
+                    // parent!!!)
+                    if (attrs.barOnMouseMove !== undefined) {
+                        scope.$eval(attrs.barOnMouseMove);
                     }
 
                     // Update the view
-                    scope.$digest();
+                    scopeToUse.$digest();
                 }
             };
 
@@ -95,20 +156,20 @@ angular.module('BeatsApp', ['Beats.filters', 'ngCookies'])
                 if (dragging)
                 {
                     // Call the callback for whenever the bar is set
-                    scope.$eval(attrs.barSet);
+                    scopeToUse.$eval(attrs.barSet);
                     dragging = false;
 
                     // Indicate that dragging has stopped
-                    scope[attrs.barDragging] = false;
+                    scopeToUse[attrs.barDragging] = false;
                 }
-            }
+            };
 
             element[0].addEventListener('mousedown', function(event)
             {
                 dragging = true;
 
                 // Indicate that dragging has started
-                scope[attrs.barDragging] = true;
+                scopeToUse[attrs.barDragging] = true;
 
                 handleDragging(event);
             });
@@ -119,6 +180,140 @@ angular.module('BeatsApp', ['Beats.filters', 'ngCookies'])
         }
     };
 })
+.directive('toggleSwitch', function()
+{
+    // Directive for having toggle slider based input switches
+    return {
+        link: function(scope, element, attrs)
+        {
+            // Get the parameters that determine how to set the value
+            var toggleOrientation = attrs.toggleOrientation;
+
+            var dragging = false;
+            var mouseMoved = false;
+
+            var handleDragging = function(event)
+            {
+                if (event === null)
+                {
+                    // Simply change the value of the toggle switch
+                    scope[attrs.toggleSwitch] = !scope[attrs.toggleSwitch];
+                }
+                else if (dragging)
+                {
+                    // The mouse moved
+                    mouseMoved = true;
+
+                    // Prevent browser's default dragging behaviour
+                    event.preventDefault();
+
+                    // Determine ratio from 0 to 1 over the control
+                    var ratio;
+                    if (toggleOrientation == 'vertical')
+                    {
+                        ratio = 1.0 - (event.clientY - element[0].offsetTop) / (element[0].offsetHeight);
+                    }
+                    else
+                    {
+                        ratio = (event.clientX - element[0].offsetLeft) / (element[0].offsetWidth);
+                    }
+
+                    // Linearly map that ratio to between barMax and barMin
+                    scope[attrs.toggleSwitch] = ratio >= 0.5;
+                }
+
+                // Update the view
+                scope.$digest();
+            };
+
+            var finishDragging = function()
+            {
+                if (dragging)
+                {
+                    // Update toggle if we didn't move the mouse
+                    if (!mouseMoved)
+                    {
+                        handleDragging(null);
+                    }
+                    mouseMoved = false;
+
+                    // Call the callback for whenever the bar is set
+                    scope.$eval(attrs.toggleSet);
+                    dragging = false;
+
+                    // Indicate that dragging has stopped
+                    scope[attrs.toggleDragging] = false;
+                }
+            };
+
+            element[0].addEventListener('mousedown', function(event)
+            {
+                dragging = true;
+
+                // Indicate that dragging has started
+                scope[attrs.toggleDragging] = true;
+            });
+
+            element[0].addEventListener('mouseup', finishDragging);
+            element[0].addEventListener('mouseleave', finishDragging);
+            element[0].addEventListener('mousemove', handleDragging);
+        }
+    };
+})
+.directive('dbTextDisplay', ['dbFormatFilter', function(dbFormatFilter)
+{
+    // Directive for having decibel label displays
+    return {
+        link: function(scope, element, attrs)
+        {
+            var dbTextIndex = attrs.dbTextIndex | 0;
+            var dbTextUseParentScope = attrs.dbTextUseParentScope;
+            var useParent = dbTextUseParentScope == 'true';
+            var scopeToUse = useParent ? scope.$parent : scope;
+
+            var updatePreampText = function()
+            {
+                element.text(dbFormatFilter(scopeToUse.eqPreampLevel));
+            };
+
+            var updateBandText = function()
+            {
+                element.text(dbFormatFilter(scopeToUse['bandLevel' + dbTextIndex]));
+            };
+
+            var updateText = function()
+            {
+                if (dbTextIndex == -1)
+                {
+                    updatePreampText();
+                }
+                else
+                {
+                    updateBandText();
+                }
+            };
+
+            scopeToUse.$on('changeDbText', function(event, args)
+            {
+                // args.index has two special sentinel values:
+                // 1) -1 means to update the text corresponding to the preamp,
+                //    which means the label corresponding to the preamp setting
+                //    should have a db-text-index value of -1.
+                // 2) -2 means to update the text no matter what it is.  In the
+                //    case of updating every single control (e.g., during a
+                //    refresh operation), this sentinel value helps reduce the
+                //    broadcast complexity from O(N^2) to O(N), where N is the
+                //    number of bands.
+                if (args.index == -2 || args.index == dbTextIndex)
+                {
+                    updateText();
+                }
+            });
+
+            updateText();
+        }
+    };
+}])
 .directive('dragSong', function()
 {
     // Directive for having bar slider based input controls
@@ -212,11 +407,13 @@ function($scope, $http, $interval, $cookies)
     //
 
     var backendBase = '/beats/1104'
+    var backendBase = '';
     var authentication = true;
 
     $scope.showLoginDialog = false;
     $scope.formUsername = '';
     $scope.formPassword = '';
+    $scope.showEqualizerDialog = false;
     $scope.showYouTubeDialog = false;
     $scope.formYouTubeURL = '';
 
@@ -225,7 +422,14 @@ function($scope, $http, $interval, $cookies)
     $scope.albumlist = [];
     $scope.queue = [];
     $scope.volume = 0;
+    $scope.eqEnabled = false;
+    $scope.eqPresets = [];
+    $scope.eqPresetIndex = 0;
+    $scope.eqPreampLevel = 0.0;
+    $scope.eqBandFrequencies = [];
     $scope.holdVolumeUpdate = false;
+    $scope.holdEqEnabledUpdate = false;
+    $scope.holdEqPreampUpdate = false;
     $scope.playbackTime = 0;
     $scope.playbackDuration = 0;
     $scope.isPlaying = false;
@@ -320,7 +524,22 @@ function($scope, $http, $interval, $cookies)
 
     $scope.isShowingDialog = function()
     {
-        return $scope.showLoginDialog || $scope.showYouTubeDialog || !!$scope.errorMessage;
+        return $scope.showLoginDialog || $scope.showEqualizerDialog || $scope.showYouTubeDialog || !!$scope.errorMessage;
+    };
+
+    $scope.startEqualizerDialog = function()
+    {
+        if (!$scope.ensureLogin())
+        {
+            return;
+        }
+        $scope.showEqualizerDialog = true;
+        $scope.equalizerFocus = true;
+    };
+
+    $scope.hideEqualizerDialog = function()
+    {
+        $scope.showEqualizerDialog = false;
     };
 
     $scope.startYouTubeDialog = function()
@@ -560,6 +779,67 @@ function($scope, $http, $interval, $cookies)
         }
     };
 
+    $scope.getEqualizerInfo = function()
+    {
+        $http.get(backendBase + '/v1/equalizer_info')
+        .success(function(data)
+        {
+            // Populate preset choices in preset menu
+            var presNames = data['equalizer_preset_names'];
+            for (var presIndex = 0; presIndex < presNames.length; presIndex++)
+            {
+                $scope.eqPresets.push({
+                    value: presIndex,
+                    displayName: presNames[presIndex]
+                });
+            }
+            // Add equalizer band controls
+            var freqs = data['equalizer_band_freqs'];
+            for (var bandIndex = 0; bandIndex < freqs.length; bandIndex++)
+            {
+                // Dynamically initialize scope variables for the band control
+                var holdName = 'holdEqBand' + bandIndex + 'Update';
+                if ($scope[holdName] === undefined)
+                {
+                    $scope[holdName] = false;
+                    $scope['bandLevel' + bandIndex] = 0.0;
+                }
+                // Add the frequency along with its corresponding band index
+                $scope.eqBandFrequencies.push({
+                    freq: freqs[bandIndex],
+                    index: bandIndex
+                });
+            }
+        });
+    };
+
+    $scope.enableEqualizer = function(enable)
+    {
+        $scope.eqEnabled = enable;
+        $scope.userRequest('/v1/player/enable_eq', 'enabled=' + enable);
+    }
+
+    $scope.adjustEqualizerPreset = function(index)
+    {
+        if ($scope.eqPresets.length > Math.floor(index))
+        {
+            $scope.eqPresetIndex = Math.floor(index);
+            $scope.userRequest('/v1/player/adjust_eq_preset', 'index=' + $scope.eqPresetIndex);
+        }
+    };
+
+    $scope.adjustEqualizerPreamp = function(level)
+    {
+        $scope.eqPreampLevel = roundDbValue(level); // Because of the bar control, this may have non-zero digits after the tenth
+        $scope.userRequest('/v1/player/adjust_eq_preamp', 'level=' + $scope.eqPreampLevel);
+    };
+
+    $scope.adjustEqualizerBand = function(level, band)
+    {
+        $scope['bandLevel' + band] = roundDbValue(level); // Because of the bar control, this may have non-zero digits after the tenth
+        $scope.userRequest('/v1/player/adjust_eq_band', 'band=' + band + '&level=' + $scope['bandLevel' + band]);
+    };
+
     $scope.playYouTube = function(url)
     {
         $scope.hideYouTubeDialog();
@@ -586,6 +866,12 @@ function($scope, $http, $interval, $cookies)
         $scope.volume = Math.round(volume); // Because of the bar control, this may be a fraction
         $scope.userRequest('/v1/player/volume', 'volume=' + $scope.volume);
     };
+    $scope.updateEqLabels = function(index)
+    {
+        $scope.$broadcast('changeDbText', {
+            index: index
+        });
+    };
     $scope.refreshPlayer = function()
     {
         $http.get(backendBase + '/v1/now_playing')
@@ -605,6 +891,37 @@ function($scope, $http, $interval, $cookies)
             {
                 $scope.volume = data['player_status']['volume'];
             }
+            // Prevent enabling/disabling the equalizer while the user is changing it
+            if (!$scope.holdEqEnabledUpdate)
+            {
+                $scope.eqEnabled = data['player_status']['equalizer_enabled'];
+            }
+            // Prevent changing the equalizer preset while the user is changing it
+            if (!$scope.holdEqPresetUpdate)
+            {
+                $scope.eqPresetIndex = data['player_status']['equalizer_preset'];
+            }
+            // Prevent changing the preamp while the user is changing it
+            if (!$scope.holdEqPreampUpdate)
+            {
+                $scope.eqPreampLevel = data['player_status']['equalizer_preamp_level'];
+            }
+            levels = data['player_status']['equalizer_band_levels'];
+            for (var bandIdx = 0; bandIdx < levels.length; bandIdx++)
+            {
+                var holdName = 'holdEqBand' + bandIdx + 'Update';
+                var hold = $scope[holdName];
+                if ($scope[holdName] === undefined)
+                {
+                    $scope[holdName] = false;
+                }
+                // Prevent changing the band while the user is changing it
+                if (!$scope[holdName])
+                {
+                    $scope['bandLevel' + bandIdx] = levels[bandIdx];
+                }
+            }
+            $scope.updateEqLabels(-2);
             $scope.isPlaying = data['player_status']['state'] == 'State.Playing';
         });
 
@@ -642,6 +959,7 @@ function($scope, $http, $interval, $cookies)
 
     $scope.requestUser();
     $scope.randomSongs();
+    $scope.getEqualizerInfo();
     $scope.refreshPlayer();
 }]);
 

--- a/static/beats.scss
+++ b/static/beats.scss
@@ -3,6 +3,8 @@ $item-shadow: 0 0 10px 0 black;
 $text-highlight-shadow: 1px 1px 1px black;
 $hover-blur: 0 0 4px #D0D9E5;
 $blue: #448AA6;
+$red: #900;
+$green: #360;
 
 @mixin ellipsis-overflow() {
     overflow-x: hidden;
@@ -363,6 +365,49 @@ table.playlist {
     z-index: 5;
 }
 
+.equalizer {
+    &.row-container {
+        align-items: center;
+        display: flex;
+        flex: 1;
+        justify-content: space-between;
+        vertical-align: middle;
+        margin: 20px;
+        &.right-aligned {
+            align-items: flex-end;
+        }
+    }
+    &.row-filler {
+        width: 100%;
+    }
+    &.preset {
+        &.label {
+            margin-left: 20px;
+            margin-right: 10px;
+        }
+        &.selector {
+            width: 100px;
+        }
+    }
+    &.preamp {
+        &.label {
+            width: 120px;
+            &.db {
+                text-align: right;
+            }
+        }
+    }
+    &.band {
+        &.ctrl-area {
+            text-align: center;
+            width: 65px;
+        }
+        &.label {
+            margin-top: 15px;
+        }
+    }
+}
+
 .control {
     color: #D0D9E5;
     cursor: default;
@@ -439,6 +484,17 @@ table.playlist {
         border-radius: 5px;
         border: 1px solid #444;
         height: 10px;
+        &.as-vertical {
+            height: none;
+            width: 10px;
+        }
+        &.as-toggle {
+            height: 18px;
+            &.as-vertical {
+                height: none;
+                width: 18px;
+            }
+        }
         position: relative;
 
         &:hover {
@@ -449,17 +505,43 @@ table.playlist {
             background-color: $blue;
             border-radius: 4px;
             height: 10px;
+            &.as-vertical {
+                height: none;
+                width: 10px;
+            }
+            &.as-toggle {
+                height: 18px;
+                &.as-off {
+                    background-color: $red;
+                }
+                &.as-on {
+                    background-color: $green;
+                }
+                &.as-vertical {
+                    height: none;
+                    width: 18px;
+                }
+            }
             position: absolute;
         }
 
         .handle {
             background: linear-gradient(to bottom, #7e868c 0%, #374044 100%);
             border-radius: 8px;
+            &.as-toggle {
+                background: linear-gradient(to bottom, #AAA 0%, #FFF 100%);
+                border-radius: 2px;
+                margin-top: 0px;
+            }
             border: 1px solid #444;
             box-shadow: 0 0 2px black;
             height: 16px;
             margin-left: -8px;
             margin-top: -4px;
+            &.as-vertical {
+                margin-left: -4px;
+                margin-right: -8px;
+            }
             position: relative;
             transition:  box-shadow 0.1s;
             width: 16px;
@@ -472,6 +554,24 @@ table.playlist {
 
     &.volume {
         width: 150px;
+    }
+
+    &.equalizer-bars {
+        padding-left: 0px;
+        padding-right: 0px;
+        margin: 0 auto;
+
+        &.on-off {
+            width: 50px;
+        }
+
+        &.preamp {
+            width: 100%;
+        }
+
+        &.band {
+            height: 250px;
+        }
     }
 
     &.track {

--- a/static/index.html
+++ b/static/index.html
@@ -221,6 +221,7 @@ Source: https://github.com/acm-uiuc/beats
              title="Equalizer"
              data-image-icon="&#xf085;"
              ng-click="startEqualizerDialog()"
+             ng-show="eqSupported"
              style="margin-right: 20px">
         </div>
         <div class="control label"

--- a/static/index.html
+++ b/static/index.html
@@ -38,6 +38,87 @@ Source: https://github.com/acm-uiuc/beats
           <span data-icon="&#xf00d;"></span>Close
         </button>
       </div>
+      <div class="dialog-area center" ng-show="showEqualizerDialog">
+        <div class="equalizer row-container">
+          <div class="control bar as-toggle equalizer-bars on-off"
+               title="{{ eqEnabled ? 'Disable' : 'Enable' }} equalizer"
+               toggle-switch="eqEnabled"
+               toggle-set="enableEqualizer(eqEnabled)"
+               toggle-dragging="holdEqEnabledUpdate">
+            <div class="cover as-toggle as-off"
+                 style="left: {{ (eqEnabled ? 1.0 : 0.0) * 100 }}%; width: {{ (eqEnabled ? 0.0 : 1.0) * 100 }}%;">
+            </div>
+            <div class="cover as-toggle as-on"
+                 style="width: {{ (eqEnabled ? 1.0 : 0.0) * 100 }}%;">
+            </div>
+            <div class="handle as-toggle"
+                 style="left: {{ (eqEnabled ? 1.0 : 0.0) * 55 + 20 }}%;">
+            </div>
+          </div>
+          <div class="equalizer preset label">Preset:</div>
+          <select title="Preset" ng-model="eqPresetIndex"
+                                 ng-change="adjustEqualizerPreset(eqPresetIndex)"
+                                 style="width: 100%">
+            <option ng-selected="{{preset.value == eqPresetIndex}}"
+                    ng-repeat="preset in eqPresets"
+                    value="{{preset.value}}">
+              {{preset.displayName}}
+            </option>
+          </select>
+        </div>
+        <div class="equalizer row-container">
+          <div class="equalizer preamp label">Preamp:</div>
+          <div class="control bar equalizer-bars preamp"
+             title="Preamp"
+             bar-control="eqPreampLevel"
+             bar-set="adjustEqualizerPreamp(eqPreampLevel)"
+             bar-on-mouse-move="updateEqLabels(-1)"
+             bar-dragging="holdEqPreampUpdate"
+             bar-min="-20"
+             bar-max="20">
+            <div class="cover"
+                 style="width: {{ (eqPreampLevel + 20)/40 * 100 }}%">
+            </div>
+            <div class="handle"
+                 style="left: {{ (eqPreampLevel + 20)/40 * 100 }}%">
+            </div>
+          </div>
+          <div class="equalizer preamp label db"
+               db-text-display="eqPreampLevel"
+               db-text-index="-1"></div>
+        </div>
+        <div class="equalizer row-container">
+          <div class="equalizer band ctrl-area" ng-repeat="band in eqBandFrequencies">
+            <div class="control bar as-vertical equalizer-bars band"
+                 title="{{ band.freq|freqFormat }}"
+                 bar-use-parent-scope="true"
+                 bar-control="bandLevel{{ band.index }}"
+                 bar-set="adjustEqualizerBand(bandLevel{{ band.index }}, {{ band.index }})"
+                 bar-on-mouse-move="updateEqLabels(band.index)"
+                 bar-dragging="holdEqBand{{ band.index }}Update"
+                 bar-min="-20"
+                 bar-max="20"
+                 bar-orientation="vertical">
+              <div class="cover as-vertical"
+                   style="top: {{ ((20 - $parent['bandLevel' + band.index])/40.0 * 100) }}%; height: {{ (($parent['bandLevel' + band.index] + 20)/40.0 * 100) }}%">
+              </div>
+              <div class="handle as-vertical"
+                   style="top: {{ ((20 - $parent['bandLevel' + band.index])/40.0 * 100) }}%">
+              </div>
+            </div>
+            <div class="equalizer band label">{{ band.freq|freqFormat }}</div>
+            <div db-text-use-parent-scope="true"
+                 db-text-display="bandLevel{{ band.index }}"
+                 db-text-index="{{ band.index }}"></div>
+          </div>
+        </div>
+        <div class="equalizer row-container">
+          <div class="equalizer row-filler"></div>
+          <button type="button" class="cancel" title="Close" ng-click="hideEqualizerDialog()">
+            <span data-icon="&#xf00d;"></span>Close
+          </button>
+        </div>
+      </div>
       <div class="dialog-area center" ng-show="showYouTubeDialog">
         <form ng-submit="playYouTube(formYouTubeURL)">
           <input placeholder="YouTube Video URL" ng-model="formYouTubeURL" take-focus="youTubeFocus" required />
@@ -136,6 +217,12 @@ Source: https://github.com/acm-uiuc/beats
              ng-click="skipSong()"
              style="margin-right: 20px">
          </div>
+        <div class="control button equalizer"
+             title="Equalizer"
+             data-image-icon="&#xf085;"
+             ng-click="startEqualizerDialog()"
+             style="margin-right: 20px">
+        </div>
         <div class="control label"
              title="Volume"
              data-image-icon="&#xf028;"

--- a/vlc.py
+++ b/vlc.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2009-2012 the VideoLAN team
 # $Id: $
 #
-# Authors: Olivier Aubert <olivier.aubert at liris.cnrs.fr>
+# Authors: Olivier Aubert <contact at olivieraubert.net>
 #          Jean Brouwers <MrJean1 at gmail.com>
 #          Geoff Salmon <geoff.salmon at gmail.com>
 #
@@ -43,12 +43,13 @@ import ctypes
 from ctypes.util import find_library
 import os
 import sys
+import functools
 
 # Used by EventManager in override.py
 from inspect import getargspec
 
 __version__ = "N/A"
-build_date  = "Tue Jul  2 10:35:53 2013"
+build_date  = "Fri Jun 19 13:45:56 2015"
 
 if sys.version_info[0] > 2:
     str = str
@@ -110,7 +111,11 @@ def find_lib():
         p = find_library('libvlc.dll')
         if p is None:
             try:  # some registry settings
-                import _winreg as w  # leaner than win32api, win32con
+                # leaner than win32api, win32con
+                if PYTHON3:
+                    import winreg as w
+                else:
+                    import _winreg as w
                 for r in w.HKEY_LOCAL_MACHINE, w.HKEY_CURRENT_USER:
                     try:
                         r = w.OpenKey(r, 'Software\\VideoLAN\\VLC')
@@ -172,6 +177,35 @@ try:
 except NameError:  # no long in Python 3+
     _Ints =  int
 _Seqs = (list, tuple)
+
+# Used for handling *event_manager() methods.
+class memoize_parameterless(object):
+    """Decorator. Caches a parameterless method's return value each time it is called.
+
+    If called later with the same arguments, the cached value is returned
+    (not reevaluated).
+    Adapted from https://wiki.python.org/moin/PythonDecoratorLibrary
+    """
+    def __init__(self, func):
+        self.func = func
+        self._cache = {}
+
+    def __call__(self, obj):
+        try:
+            return self._cache[obj]
+        except KeyError:
+            v = self._cache[obj] = self.func(obj)
+            return v
+
+    def __repr__(self):
+        """Return the function's docstring.
+        """
+        return self.func.__doc__
+
+    def __get__(self, obj, objtype):
+      """Support instance methods.
+      """
+      return functools.partial(self.__call__, obj)
 
 # Default instance. It is used to instanciate classes directly in the
 # OO-wrapper.
@@ -365,6 +399,7 @@ class EventType(_Enum):
         3: 'MediaParsedChanged',
         4: 'MediaFreed',
         5: 'MediaStateChanged',
+        6: 'MediaSubItemTreeAdded',
         0x100: 'MediaPlayerMediaChanged',
         257: 'MediaPlayerNothingSpecial',
         258: 'MediaPlayerOpening',
@@ -384,10 +419,15 @@ class EventType(_Enum):
         272: 'MediaPlayerSnapshotTaken',
         273: 'MediaPlayerLengthChanged',
         274: 'MediaPlayerVout',
+        275: 'MediaPlayerScrambledChanged',
+        276: 'MediaPlayerESAdded',
+        277: 'MediaPlayerESDeleted',
+        278: 'MediaPlayerESSelected',
         0x200: 'MediaListItemAdded',
         513: 'MediaListWillAddItem',
         514: 'MediaListItemDeleted',
         515: 'MediaListWillDeleteItem',
+        516: 'MediaListEndReached',
         0x300: 'MediaListViewItemAdded',
         769: 'MediaListViewWillAddItem',
         770: 'MediaListViewItemDeleted',
@@ -413,6 +453,7 @@ EventType.MediaDiscovererEnded          = EventType(1281)
 EventType.MediaDiscovererStarted        = EventType(0x500)
 EventType.MediaDurationChanged          = EventType(2)
 EventType.MediaFreed                    = EventType(4)
+EventType.MediaListEndReached           = EventType(516)
 EventType.MediaListItemAdded            = EventType(0x200)
 EventType.MediaListItemDeleted          = EventType(514)
 EventType.MediaListPlayerNextItemSet    = EventType(1025)
@@ -428,6 +469,9 @@ EventType.MediaMetaChanged              = EventType(0)
 EventType.MediaParsedChanged            = EventType(3)
 EventType.MediaPlayerBackward           = EventType(264)
 EventType.MediaPlayerBuffering          = EventType(259)
+EventType.MediaPlayerESAdded            = EventType(276)
+EventType.MediaPlayerESDeleted          = EventType(277)
+EventType.MediaPlayerESSelected         = EventType(278)
 EventType.MediaPlayerEncounteredError   = EventType(266)
 EventType.MediaPlayerEndReached         = EventType(265)
 EventType.MediaPlayerForward            = EventType(263)
@@ -439,6 +483,7 @@ EventType.MediaPlayerPausableChanged    = EventType(270)
 EventType.MediaPlayerPaused             = EventType(261)
 EventType.MediaPlayerPlaying            = EventType(260)
 EventType.MediaPlayerPositionChanged    = EventType(268)
+EventType.MediaPlayerScrambledChanged   = EventType(275)
 EventType.MediaPlayerSeekableChanged    = EventType(269)
 EventType.MediaPlayerSnapshotTaken      = EventType(272)
 EventType.MediaPlayerStopped            = EventType(262)
@@ -447,6 +492,7 @@ EventType.MediaPlayerTitleChanged       = EventType(271)
 EventType.MediaPlayerVout               = EventType(274)
 EventType.MediaStateChanged             = EventType(5)
 EventType.MediaSubItemAdded             = EventType(1)
+EventType.MediaSubItemTreeAdded         = EventType(6)
 EventType.VlmMediaAdded                 = EventType(0x600)
 EventType.VlmMediaChanged               = EventType(1538)
 EventType.VlmMediaInstanceStarted       = EventType(1539)
@@ -480,23 +526,39 @@ class Meta(_Enum):
         14: 'EncodedBy',
         15: 'ArtworkURL',
         16: 'TrackID',
+        17: 'TrackTotal',
+        18: 'Director',
+        19: 'Season',
+        20: 'Episode',
+        21: 'ShowName',
+        22: 'Actors',
+        23: 'AlbumArtist',
+        24: 'DiscNumber',
     }
+Meta.Actors      = Meta(22)
 Meta.Album       = Meta(4)
+Meta.AlbumArtist = Meta(23)
 Meta.Artist      = Meta(1)
 Meta.ArtworkURL  = Meta(15)
 Meta.Copyright   = Meta(3)
 Meta.Date        = Meta(8)
 Meta.Description = Meta(6)
+Meta.Director    = Meta(18)
+Meta.DiscNumber  = Meta(24)
 Meta.EncodedBy   = Meta(14)
+Meta.Episode     = Meta(20)
 Meta.Genre       = Meta(2)
 Meta.Language    = Meta(11)
 Meta.NowPlaying  = Meta(12)
 Meta.Publisher   = Meta(13)
 Meta.Rating      = Meta(7)
+Meta.Season      = Meta(19)
 Meta.Setting     = Meta(9)
+Meta.ShowName    = Meta(21)
 Meta.Title       = Meta(0)
 Meta.TrackID     = Meta(16)
 Meta.TrackNumber = Meta(5)
+Meta.TrackTotal  = Meta(17)
 Meta.URL         = Meta(10)
 
 class State(_Enum):
@@ -539,6 +601,40 @@ TrackType.audio   = TrackType(0)
 TrackType.text    = TrackType(2)
 TrackType.unknown = TrackType(-1)
 TrackType.video   = TrackType(1)
+
+class MediaType(_Enum):
+    '''Media type
+See libvlc_media_get_type.
+    '''
+    _enum_names_ = {
+        0: 'unknown',
+        1: 'file',
+        2: 'directory',
+        3: 'disc',
+        4: 'stream',
+        5: 'playlist',
+    }
+MediaType.directory = MediaType(2)
+MediaType.disc      = MediaType(3)
+MediaType.file      = MediaType(1)
+MediaType.playlist  = MediaType(5)
+MediaType.stream    = MediaType(4)
+MediaType.unknown   = MediaType(0)
+
+class MediaParseFlag(_Enum):
+    '''Parse flags used by libvlc_media_parse_with_options()
+See libvlc_media_parse_with_options.
+    '''
+    _enum_names_ = {
+        0x00: 'local',
+        0x01: 'network',
+        0x02: 'local',
+        0x04: 'network',
+    }
+MediaParseFlag.local   = MediaParseFlag(0x00)
+MediaParseFlag.local   = MediaParseFlag(0x02)
+MediaParseFlag.network = MediaParseFlag(0x01)
+MediaParseFlag.network = MediaParseFlag(0x04)
 
 class PlaybackMode(_Enum):
     '''Defines playback modes for playlist.
@@ -593,6 +689,32 @@ NavigateMode.down     = NavigateMode(2)
 NavigateMode.left     = NavigateMode(3)
 NavigateMode.right    = NavigateMode(4)
 NavigateMode.up       = NavigateMode(1)
+
+class Position(_Enum):
+    '''Enumeration of values used to set position (e.g. of video title).
+    '''
+    _enum_names_ = {
+        -1: 'disable',
+        0: 'center',
+        1: 'left',
+        2: 'right',
+        3: 'top',
+        4: 'left',
+        5: 'right',
+        6: 'bottom',
+        7: 'left',
+        8: 'right',
+    }
+Position.bottom  = Position(6)
+Position.center  = Position(0)
+Position.disable = Position(-1)
+Position.left    = Position(1)
+Position.left    = Position(4)
+Position.left    = Position(7)
+Position.right   = Position(2)
+Position.right   = Position(5)
+Position.right   = Position(8)
+Position.top     = Position(3)
 
 class VideoLogoOption(_Enum):
     '''Option values for libvlc_video_{get,set}_logo_{int,string}.
@@ -684,13 +806,56 @@ class Callback(ctypes.c_void_p):
 class LogCb(ctypes.c_void_p):
     """Callback prototype for LibVLC log message handler.
 \param data data pointer as given to L{libvlc_log_set}()
-\param level message level (@ref enum libvlc_log_level)
-\param ctx message context (meta-informations about the message)
+\param level message level (@ref libvlc_log_level)
+\param ctx message context (meta-information about the message)
 \param fmt printf() format string (as defined by ISO C11)
 \param args variable argument list for the format
 \note Log message handlers <b>must</b> be thread-safe.
 \warning The message context pointer, the format string parameters and the
          variable arguments are only valid until the callback returns.
+    """
+    pass
+class MediaOpenCb(ctypes.c_void_p):
+    """Callback prototype to open a custom bitstream input media.
+The same media item can be opened multiple times. Each time, this callback
+is invoked. It should allocate and initialize any instance-specific
+resources, then store them in *datap. The instance resources can be freed
+in the @ref libvlc_media_close_cb callback.
+\param opaque private pointer as passed to L{libvlc_media_new_callbacks}()
+\param datap storage space for a private data pointer [OUT]
+\param sizep byte length of the bitstream or 0 if unknown [OUT]
+\note For convenience, *datap is initially NULL and *sizep is initially 0.
+\return 0 on success, non-zero on error. In case of failure, the other
+callbacks will not be invoked and any value stored in *datap and *sizep is
+discarded.
+    """
+    pass
+class MediaReadCb(ctypes.c_void_p):
+    """Callback prototype to read data from a custom bitstream input media.
+\param opaque private pointer as set by the @ref libvlc_media_open_cb
+              callback
+\param buf start address of the buffer to read data into
+\param len bytes length of the buffer
+\return strictly positive number of bytes read, 0 on end-of-stream,
+        or -1 on non-recoverable error
+\note If no data is immediately available, then the callback should sleep.
+\warning The application is responsible for avoiding deadlock situations.
+In particular, the callback should return an error if playback is stopped;
+if it does not return, then L{libvlc_media_player_stop}() will never return.
+    """
+    pass
+class MediaSeekCb(ctypes.c_void_p):
+    """Callback prototype to seek a custom bitstream input media.
+\param opaque private pointer as set by the @ref libvlc_media_open_cb
+              callback
+\param offset absolute byte offset to seek to
+\return 0 on success, -1 on error.
+    """
+    pass
+class MediaCloseCb(ctypes.c_void_p):
+    """Callback prototype to close a custom bitstream input media.
+\param opaque private pointer as set by the @ref libvlc_media_open_cb
+              callback
     """
     pass
 class VideoLockCb(ctypes.c_void_p):
@@ -750,7 +915,7 @@ the number of bytes per pixel multiplied by the pixel width.
 Similarly, the number of scanlines must be bigger than of equal to
 the pixel height.
 Furthermore, we recommend that pitches and lines be multiple of 32
-to not break assumption that might be made by various optimizations
+to not break assumptions that might be held by optimized code
 in the video decoders, video filters and/or video converters.
     """
     pass
@@ -827,13 +992,52 @@ class CallbackDecorators(object):
     LogCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int, Log_ptr, ctypes.c_char_p, ctypes.c_void_p)
     LogCb.__doc__ = '''Callback prototype for LibVLC log message handler.
 \param data data pointer as given to L{libvlc_log_set}()
-\param level message level (@ref enum libvlc_log_level)
-\param ctx message context (meta-informations about the message)
+\param level message level (@ref libvlc_log_level)
+\param ctx message context (meta-information about the message)
 \param fmt printf() format string (as defined by ISO C11)
 \param args variable argument list for the format
 \note Log message handlers <b>must</b> be thread-safe.
 \warning The message context pointer, the format string parameters and the
          variable arguments are only valid until the callback returns.
+    ''' 
+    MediaOpenCb = ctypes.CFUNCTYPE(ctypes.POINTER(ctypes.c_int), ctypes.c_void_p, ListPOINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_uint64))
+    MediaOpenCb.__doc__ = '''Callback prototype to open a custom bitstream input media.
+The same media item can be opened multiple times. Each time, this callback
+is invoked. It should allocate and initialize any instance-specific
+resources, then store them in *datap. The instance resources can be freed
+in the @ref libvlc_media_close_cb callback.
+\param opaque private pointer as passed to L{libvlc_media_new_callbacks}()
+\param datap storage space for a private data pointer [OUT]
+\param sizep byte length of the bitstream or 0 if unknown [OUT]
+\note For convenience, *datap is initially NULL and *sizep is initially 0.
+\return 0 on success, non-zero on error. In case of failure, the other
+callbacks will not be invoked and any value stored in *datap and *sizep is
+discarded.
+    ''' 
+    MediaReadCb = ctypes.CFUNCTYPE(ctypes.POINTER(ctypes.c_ssize_t), ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t)
+    MediaReadCb.__doc__ = '''Callback prototype to read data from a custom bitstream input media.
+\param opaque private pointer as set by the @ref libvlc_media_open_cb
+              callback
+\param buf start address of the buffer to read data into
+\param len bytes length of the buffer
+\return strictly positive number of bytes read, 0 on end-of-stream,
+        or -1 on non-recoverable error
+\note If no data is immediately available, then the callback should sleep.
+\warning The application is responsible for avoiding deadlock situations.
+In particular, the callback should return an error if playback is stopped;
+if it does not return, then L{libvlc_media_player_stop}() will never return.
+    ''' 
+    MediaSeekCb = ctypes.CFUNCTYPE(ctypes.POINTER(ctypes.c_int), ctypes.c_void_p, ctypes.c_uint64)
+    MediaSeekCb.__doc__ = '''Callback prototype to seek a custom bitstream input media.
+\param opaque private pointer as set by the @ref libvlc_media_open_cb
+              callback
+\param offset absolute byte offset to seek to
+\return 0 on success, -1 on error.
+    ''' 
+    MediaCloseCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)
+    MediaCloseCb.__doc__ = '''Callback prototype to close a custom bitstream input media.
+\param opaque private pointer as set by the @ref libvlc_media_open_cb
+              callback
     ''' 
     VideoLockCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ListPOINTER(ctypes.c_void_p))
     VideoLockCb.__doc__ = '''Callback prototype to allocate and lock a picture buffer.
@@ -889,7 +1093,7 @@ the number of bytes per pixel multiplied by the pixel width.
 Similarly, the number of scanlines must be bigger than of equal to
 the pixel height.
 Furthermore, we recommend that pitches and lines be multiple of 32
-to not break assumption that might be made by various optimizations
+to not break assumptions that might be held by optimized code
 in the video decoders, video filters and/or video converters.
     ''' 
     VideoCleanupCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)
@@ -1193,6 +1397,20 @@ AudioOutputDevice._fields_ = [  # recursive struct
     ('description', ctypes.c_char_p),
     ]
 
+class TitleDescription(_Cstruct):
+    _fields = [
+        ('duration', ctypes.c_longlong),
+        ('name', ctypes.c_char_p),
+        ('menu', ctypes.c_bool),
+    ]
+
+class ChapterDescription(_Cstruct):
+    _fields = [
+        ('time_offset', ctypes.c_longlong),
+        ('duration', ctypes.c_longlong),
+        ('name', ctypes.c_char_p),
+    ]
+
  # End of header.py #
 
 class EventManager(_Ctype):
@@ -1338,13 +1556,14 @@ class Instance(_Ctype):
         local path. If you need more control, directly use
         media_new_location/media_new_path methods.
 
-        Options can be specified as supplementary string parameters, e.g.
+        Options can be specified as supplementary string parameters,
+        but note that many options cannot be set at the media level,
+        and rather at the Instance level. For instance, the marquee
+        filter must be specified when creating the vlc.Instance or
+        vlc.MediaPlayer.
 
-        C{m = i.media_new('foo.avi', 'sub-filter=marq{marquee=Hello}', 'vout-filter=invert')}
-
-        Alternatively, the options can be added to the media using the Media.add_options method:
-
-        C{m.add_options('foo.avi', 'sub-filter=marq@test{marquee=Hello}', 'video-filter=invert')}
+        Alternatively, options can be added to the media using the
+        Media.add_options method (with the same limitation).
 
         @param options: optional media option=value strings
         """
@@ -1404,25 +1623,29 @@ class Instance(_Ctype):
         return module_description_list(libvlc_video_filter_list_get(self))
 
 
+    
     def release(self):
         '''Decrement the reference count of a libvlc instance, and destroy it
         if it reaches zero.
         '''
         return libvlc_release(self)
 
+    
     def retain(self):
         '''Increments the reference count of a libvlc instance.
         The initial reference count is 1 after L{new}() returns.
         '''
         return libvlc_retain(self)
 
+    
     def add_intf(self, name):
         '''Try to start a user interface for the libvlc instance.
-        @param name: interface name, or NULL for default.
+        @param name: interface name, or None for default.
         @return: 0 on success, -1 on error.
         '''
         return libvlc_add_intf(self, str_to_bytes(name))
 
+    
     def set_user_agent(self, name, http):
         '''Sets the application name. LibVLC passes this as the user agent string
         when a protocol requires it.
@@ -1432,6 +1655,18 @@ class Instance(_Ctype):
         '''
         return libvlc_set_user_agent(self, str_to_bytes(name), str_to_bytes(http))
 
+    
+    def set_app_id(self, id, version, icon):
+        '''Sets some meta-information about the application.
+        See also L{set_user_agent}().
+        @param id: Java-style application identifier, e.g. "com.acme.foobar".
+        @param version: application version numbers, e.g. "1.2.3".
+        @param icon: application icon name, e.g. "foobar".
+        @version: LibVLC 2.1.0 or later.
+        '''
+        return libvlc_set_app_id(self, str_to_bytes(id), str_to_bytes(version), str_to_bytes(icon))
+
+    
     def log_unset(self):
         '''Unsets the logging callback for a LibVLC instance. This is rarely needed:
         the callback is implicitly unset when the instance is destroyed.
@@ -1441,6 +1676,7 @@ class Instance(_Ctype):
         '''
         return libvlc_log_unset(self)
 
+    
     def log_set(self, data, p_instance):
         '''Sets the logging callback for a LibVLC instance.
         This function is thread-safe: it will wait for any pending callbacks
@@ -1451,6 +1687,7 @@ class Instance(_Ctype):
         '''
         return libvlc_log_set(self, data, p_instance)
 
+    
     def log_set_file(self, stream):
         '''Sets up logging to a file.
         @param stream: FILE pointer opened for writing (the FILE pointer must remain valid until L{log_unset}()).
@@ -1458,6 +1695,7 @@ class Instance(_Ctype):
         '''
         return libvlc_log_set_file(self, stream)
 
+    
     def media_new_location(self, psz_mrl):
         '''Create a media with a certain given media resource location,
         for instance a valid URL.
@@ -1467,18 +1705,20 @@ class Instance(_Ctype):
         local files.
         See L{media_release}.
         @param psz_mrl: the media location.
-        @return: the newly created media or NULL on error.
+        @return: the newly created media or None on error.
         '''
         return libvlc_media_new_location(self, str_to_bytes(psz_mrl))
 
+    
     def media_new_path(self, path):
         '''Create a media for a certain file path.
         See L{media_release}.
         @param path: local filesystem path.
-        @return: the newly created media or NULL on error.
+        @return: the newly created media or None on error.
         '''
         return libvlc_media_new_path(self, str_to_bytes(path))
 
+    
     def media_new_fd(self, fd):
         '''Create a media for an already open file descriptor.
         The file descriptor shall be open for reading (or reading and writing).
@@ -1494,42 +1734,70 @@ class Instance(_Ctype):
         descriptor should probably be rewound to the beginning with lseek().
         See L{media_release}.
         @param fd: open file descriptor.
-        @return: the newly created media or NULL on error.
+        @return: the newly created media or None on error.
         @version: LibVLC 1.1.5 and later.
         '''
         return libvlc_media_new_fd(self, fd)
 
+    
+    def media_new_callbacks(self, open_cb, read_cb, seek_cb, close_cb, opaque):
+        '''Create a media with custom callbacks to read the data from.
+        @param open_cb: callback to open the custom bitstream input media.
+        @param read_cb: callback to read data (must not be None).
+        @param seek_cb: callback to seek, or None if seeking is not supported.
+        @param close_cb: callback to close the media, or None if unnecessary.
+        @param opaque: data pointer for the open callback.
+        @return: the newly created media or None on error @note If open_cb is None, the opaque pointer will be passed to read_cb, seek_cb and close_cb, and the stream size will be treated as unknown. @note The callbacks may be called asynchronously (from another thread). A single stream instance need not be reentrant. However the open_cb needs to be reentrant if the media is used by multiple player instances. @warning The callbacks may be used until all or any player instances that were supplied the media item are stopped. See L{media_release}.
+        @version: LibVLC 3.0.0 and later.
+        '''
+        return libvlc_media_new_callbacks(self, open_cb, read_cb, seek_cb, close_cb, opaque)
+
+    
     def media_new_as_node(self, psz_name):
         '''Create a media as an empty node with a given name.
         See L{media_release}.
         @param psz_name: the name of the node.
-        @return: the new empty media or NULL on error.
+        @return: the new empty media or None on error.
         '''
         return libvlc_media_new_as_node(self, str_to_bytes(psz_name))
 
-    def media_discoverer_new_from_name(self, psz_name):
-        '''Discover media service by name.
+    
+    def media_discoverer_new(self, psz_name):
+        '''Create a media discoverer object by name.
+        After this object is created, you should attach to events in order to be
+        notified of the discoverer state.
+        You should also attach to media_list events in order to be notified of new
+        items discovered.
+        You need to call L{media_discoverer_start}() in order to start the
+        discovery.
+        See L{media_discoverer_media_list}
+        See L{media_discoverer_event_manager}
+        See L{media_discoverer_start}.
         @param psz_name: service name.
-        @return: media discover object or NULL in case of error.
+        @return: media discover object or None in case of error.
+        @version: LibVLC 3.0.0 or later.
         '''
-        return libvlc_media_discoverer_new_from_name(self, str_to_bytes(psz_name))
+        return libvlc_media_discoverer_new(self, str_to_bytes(psz_name))
 
+    
     def media_library_new(self):
         '''Create an new Media Library object.
-        @return: a new object or NULL on error.
+        @return: a new object or None on error.
         '''
         return libvlc_media_library_new(self)
 
+    
     def audio_output_list_get(self):
-        '''Gets the list of available audio outputs.
-        @return: list of available audio outputs. It must be freed it with In case of error, NULL is returned.
+        '''Gets the list of available audio output modules.
+        @return: list of available audio outputs. It must be freed with In case of error, None is returned.
         '''
         return libvlc_audio_output_list_get(self)
 
+    
     def audio_output_device_list_get(self, aout):
-        '''Gets a list of audio output devices for a given audio output.
+        '''Gets a list of audio output devices for a given audio output module,
         See L{audio_output_device_set}().
-        @note: Not all audio outputs support this. In particular, an empty (NULL)
+        @note: Not all audio outputs support this. In particular, an empty (None)
         list of devices does B{not} imply that the specified audio output does
         not work.
         @note: The list might not be exhaustive.
@@ -1537,16 +1805,18 @@ class Instance(_Ctype):
         some circumstances. By default, it is recommended to not specify any
         explicit audio device.
         @param psz_aout: audio output name (as returned by L{audio_output_list_get}()).
-        @return: A NULL-terminated linked list of potential audio output devices. It must be freed it with L{audio_output_device_list_release}().
+        @return: A None-terminated linked list of potential audio output devices. It must be freed with L{audio_output_device_list_release}().
         @version: LibVLC 2.1.0 or later.
         '''
         return libvlc_audio_output_device_list_get(self, str_to_bytes(aout))
 
+    
     def vlm_release(self):
         '''Release the vlm instance related to the given L{Instance}.
         '''
         return libvlc_vlm_release(self)
 
+    
     def vlm_add_broadcast(self, psz_name, psz_input, psz_output, i_options, ppsz_options, b_enabled, b_loop):
         '''Add a broadcast, with one input.
         @param psz_name: the name of the new broadcast.
@@ -1560,6 +1830,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_add_broadcast(self, str_to_bytes(psz_name), str_to_bytes(psz_input), str_to_bytes(psz_output), i_options, ppsz_options, b_enabled, b_loop)
 
+    
     def vlm_add_vod(self, psz_name, psz_input, i_options, ppsz_options, b_enabled, psz_mux):
         '''Add a vod, with one input.
         @param psz_name: the name of the new vod media.
@@ -1572,6 +1843,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_add_vod(self, str_to_bytes(psz_name), str_to_bytes(psz_input), i_options, ppsz_options, b_enabled, str_to_bytes(psz_mux))
 
+    
     def vlm_del_media(self, psz_name):
         '''Delete a media (VOD or broadcast).
         @param psz_name: the media to delete.
@@ -1579,6 +1851,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_del_media(self, str_to_bytes(psz_name))
 
+    
     def vlm_set_enabled(self, psz_name, b_enabled):
         '''Enable or disable a media (VOD or broadcast).
         @param psz_name: the media to work on.
@@ -1587,6 +1860,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_set_enabled(self, str_to_bytes(psz_name), b_enabled)
 
+    
     def vlm_set_output(self, psz_name, psz_output):
         '''Set the output for a media.
         @param psz_name: the media to work on.
@@ -1595,6 +1869,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_set_output(self, str_to_bytes(psz_name), str_to_bytes(psz_output))
 
+    
     def vlm_set_input(self, psz_name, psz_input):
         '''Set a media's input MRL. This will delete all existing inputs and
         add the specified one.
@@ -1604,6 +1879,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_set_input(self, str_to_bytes(psz_name), str_to_bytes(psz_input))
 
+    
     def vlm_add_input(self, psz_name, psz_input):
         '''Add a media's input MRL. This will add the specified one.
         @param psz_name: the media to work on.
@@ -1612,6 +1888,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_add_input(self, str_to_bytes(psz_name), str_to_bytes(psz_input))
 
+    
     def vlm_set_loop(self, psz_name, b_loop):
         '''Set a media's loop status.
         @param psz_name: the media to work on.
@@ -1620,6 +1897,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_set_loop(self, str_to_bytes(psz_name), b_loop)
 
+    
     def vlm_set_mux(self, psz_name, psz_mux):
         '''Set a media's vod muxer.
         @param psz_name: the media to work on.
@@ -1628,6 +1906,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_set_mux(self, str_to_bytes(psz_name), str_to_bytes(psz_mux))
 
+    
     def vlm_change_media(self, psz_name, psz_input, psz_output, i_options, ppsz_options, b_enabled, b_loop):
         '''Edit the parameters of a media. This will delete all existing inputs and
         add the specified one.
@@ -1642,6 +1921,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_change_media(self, str_to_bytes(psz_name), str_to_bytes(psz_input), str_to_bytes(psz_output), i_options, ppsz_options, b_enabled, b_loop)
 
+    
     def vlm_play_media(self, psz_name):
         '''Play the named broadcast.
         @param psz_name: the name of the broadcast.
@@ -1649,6 +1929,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_play_media(self, str_to_bytes(psz_name))
 
+    
     def vlm_stop_media(self, psz_name):
         '''Stop the named broadcast.
         @param psz_name: the name of the broadcast.
@@ -1656,6 +1937,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_stop_media(self, str_to_bytes(psz_name))
 
+    
     def vlm_pause_media(self, psz_name):
         '''Pause the named broadcast.
         @param psz_name: the name of the broadcast.
@@ -1663,6 +1945,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_pause_media(self, str_to_bytes(psz_name))
 
+    
     def vlm_seek_media(self, psz_name, f_percentage):
         '''Seek in the named broadcast.
         @param psz_name: the name of the broadcast.
@@ -1671,6 +1954,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_seek_media(self, str_to_bytes(psz_name), f_percentage)
 
+    
     def vlm_show_media(self, psz_name):
         '''Return information about the named media as a JSON
         string representation.
@@ -1681,10 +1965,11 @@ class Instance(_Ctype):
         Currently there are no such functions available for
         vlm_media_t though.
         @param psz_name: the name of the media, if the name is an empty string, all media is described.
-        @return: string with information about named media, or NULL on error.
+        @return: string with information about named media, or None on error.
         '''
         return libvlc_vlm_show_media(self, str_to_bytes(psz_name))
 
+    
     def vlm_get_media_instance_position(self, psz_name, i_instance):
         '''Get vlm_media instance position by name or instance id.
         @param psz_name: name of vlm media instance.
@@ -1693,6 +1978,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_position(self, str_to_bytes(psz_name), i_instance)
 
+    
     def vlm_get_media_instance_time(self, psz_name, i_instance):
         '''Get vlm_media instance time by name or instance id.
         @param psz_name: name of vlm media instance.
@@ -1701,6 +1987,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_time(self, str_to_bytes(psz_name), i_instance)
 
+    
     def vlm_get_media_instance_length(self, psz_name, i_instance):
         '''Get vlm_media instance length by name or instance id.
         @param psz_name: name of vlm media instance.
@@ -1709,6 +1996,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_length(self, str_to_bytes(psz_name), i_instance)
 
+    
     def vlm_get_media_instance_rate(self, psz_name, i_instance):
         '''Get vlm_media instance playback rate by name or instance id.
         @param psz_name: name of vlm media instance.
@@ -1717,6 +2005,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_rate(self, str_to_bytes(psz_name), i_instance)
 
+    
     def vlm_get_media_instance_title(self, psz_name, i_instance):
         '''Get vlm_media instance title number by name or instance id.
         @param psz_name: name of vlm media instance.
@@ -1726,6 +2015,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_title(self, str_to_bytes(psz_name), i_instance)
 
+    
     def vlm_get_media_instance_chapter(self, psz_name, i_instance):
         '''Get vlm_media instance chapter number by name or instance id.
         @param psz_name: name of vlm media instance.
@@ -1735,6 +2025,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_chapter(self, str_to_bytes(psz_name), i_instance)
 
+    
     def vlm_get_media_instance_seekable(self, psz_name, i_instance):
         '''Is libvlc instance seekable ?
         @param psz_name: name of vlm media instance.
@@ -1744,6 +2035,7 @@ class Instance(_Ctype):
         '''
         return libvlc_vlm_get_media_instance_seekable(self, str_to_bytes(psz_name), i_instance)
 
+    @memoize_parameterless
     def vlm_get_event_manager(self):
         '''Get libvlc_event_manager from a vlm media.
         The p_event_manager is immutable, so you don't have to hold the lock.
@@ -1777,20 +2069,31 @@ class Media(_Ctype):
     def add_options(self, *options):
         """Add a list of options to the media.
 
-        Options must be written without the double-dash, e.g.:
-
-        C{m.add_options('sub-filter=marq@test{marquee=Hello}', 'video-filter=invert')}
-
-        Alternatively, the options can directly be passed in the Instance.media_new method:
-
-        C{m = instance.media_new('foo.avi', 'sub-filter=marq@test{marquee=Hello}', 'video-filter=invert')}
+        Options must be written without the double-dash. Warning: most
+        audio and video options, such as text renderer, have no
+        effects on an individual media. These options must be set at
+        the vlc.Instance or vlc.MediaPlayer instanciation.
 
         @param options: optional media option=value strings
         """
         for o in options:
             self.add_option(o)
 
+    def tracks_get(self):
+        """Get media descriptor's elementary streams description
+        Note, you need to call L{parse}() or play the media at least once
+        before calling this function.
+        Not doing this will result in an empty array.
+        The result must be freed with L{tracks_release}.
+        @version: LibVLC 2.1.0 and later.
+        """
+        mediaTrack_pp = ctypes.POINTER(MediaTrack)()
+        n = libvlc_media_tracks_get(self, ctypes.byref(mediaTrack_pp))
+        info = ctypes.cast(ctypes.mediaTrack_pp, ctypes.POINTER(ctypes.POINTER(MediaTrack) * n))
+        return info
 
+
+    
     def add_option(self, psz_options):
         '''Add an option to the media.
         This option will be used to determine how the media_player will
@@ -1807,6 +2110,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_add_option(self, str_to_bytes(psz_options))
 
+    
     def add_option_flag(self, psz_options, i_flags):
         '''Add an option to the media with configurable flags.
         This option will be used to determine how the media_player will
@@ -1822,6 +2126,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_add_option_flag(self, str_to_bytes(psz_options), i_flags)
 
+    
     def retain(self):
         '''Retain a reference to a media descriptor object (libvlc_media_t). Use
         L{release}() to decrement the reference count of a
@@ -1829,6 +2134,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_retain(self)
 
+    
     def release(self):
         '''Decrement the reference count of a media descriptor object. If the
         reference count is 0, then L{release}() will release the
@@ -1838,20 +2144,23 @@ class Media(_Ctype):
         '''
         return libvlc_media_release(self)
 
+    
     def get_mrl(self):
         '''Get the media resource locator (mrl) from a media descriptor object.
         @return: string with mrl of media descriptor object.
         '''
         return libvlc_media_get_mrl(self)
 
+    
     def duplicate(self):
         '''Duplicate a media descriptor object.
         '''
         return libvlc_media_duplicate(self)
 
+    
     def get_meta(self, e_meta):
         '''Read the meta of the media.
-        If the media has not yet been parsed this will return NULL.
+        If the media has not yet been parsed this will return None.
         This methods automatically calls L{parse_async}(), so after calling
         it you may receive a libvlc_MediaMetaChanged event. If you prefer a synchronous
         version ensure that you call L{parse}() before get_meta().
@@ -1863,6 +2172,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_get_meta(self, e_meta)
 
+    
     def set_meta(self, e_meta, psz_value):
         '''Set the meta of the media (this function will not save the meta, call
         L{save_meta} in order to save the meta).
@@ -1871,12 +2181,14 @@ class Media(_Ctype):
         '''
         return libvlc_media_set_meta(self, e_meta, str_to_bytes(psz_value))
 
+    
     def save_meta(self):
         '''Save the meta previously set.
         @return: true if the write operation was successful.
         '''
         return libvlc_media_save_meta(self)
 
+    
     def get_state(self):
         '''Get current state of media descriptor object. Possible media states
         are defined in libvlc_structures.c ( libvlc_NothingSpecial=0,
@@ -1888,6 +2200,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_get_state(self)
 
+    
     def get_stats(self, p_stats):
         '''Get the current statistics about the media.
         @param p_stats:: structure that contain the statistics about the media (this structure must be allocated by the caller).
@@ -1895,14 +2208,16 @@ class Media(_Ctype):
         '''
         return libvlc_media_get_stats(self, p_stats)
 
+    
     def subitems(self):
         '''Get subitems of media descriptor object. This will increment
         the reference count of supplied media descriptor object. Use
         L{list_release}() to decrement the reference counting.
-        @return: list of media descriptor subitems or NULL.
+        @return: list of media descriptor subitems or None.
         '''
         return libvlc_media_subitems(self)
 
+    @memoize_parameterless
     def event_manager(self):
         '''Get event manager from media descriptor object.
         NOTE: this function doesn't increment reference counting.
@@ -1910,15 +2225,17 @@ class Media(_Ctype):
         '''
         return libvlc_media_event_manager(self)
 
+    
     def get_duration(self):
         '''Get duration (in ms) of media descriptor object item.
         @return: duration of media item or -1 on error.
         '''
         return libvlc_media_get_duration(self)
 
+    
     def parse(self):
         '''Parse a media.
-        This fetches (local) meta data and tracks information.
+        This fetches (local) art, meta data and tracks information.
         The method is synchronous.
         See L{parse_async}
         See L{get_meta}
@@ -1926,9 +2243,10 @@ class Media(_Ctype):
         '''
         return libvlc_media_parse(self)
 
+    
     def parse_async(self):
         '''Parse a media.
-        This fetches (local) meta data and tracks information.
+        This fetches (local) art, meta data and tracks information.
         The method is the asynchronous of L{parse}().
         To track when this is over you can listen to libvlc_MediaParsedChanged
         event. However if the media was already parsed you will not receive this
@@ -1940,6 +2258,28 @@ class Media(_Ctype):
         '''
         return libvlc_media_parse_async(self)
 
+    
+    def parse_with_options(self, parse_flag):
+        '''Parse the media asynchronously with options.
+        This fetches (local or network) art, meta data and/or tracks information.
+        This method is the extended version of L{parse_async}().
+        To track when this is over you can listen to libvlc_MediaParsedChanged
+        event. However if this functions returns an error, you will not receive this
+        event.
+        It uses a flag to specify parse options (see libvlc_media_parse_flag_t). All
+        these flags can be combined. By default, media is parsed if it's a local
+        file.
+        See libvlc_MediaParsedChanged
+        See L{get_meta}
+        See L{tracks_get}
+        See libvlc_media_parse_flag_t.
+        @param parse_flag: parse options:
+        @return: -1 in case of error, 0 otherwise.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_media_parse_with_options(self, parse_flag)
+
+    
     def is_parsed(self):
         '''Get Parsed status for media descriptor object.
         See libvlc_MediaParsedChanged.
@@ -1947,6 +2287,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_is_parsed(self)
 
+    
     def set_user_data(self, p_new_user_data):
         '''Sets media descriptor's user_data. user_data is specialized data
         accessed by the host application, VLC.framework uses it as a pointer to
@@ -1955,6 +2296,7 @@ class Media(_Ctype):
         '''
         return libvlc_media_set_user_data(self, p_new_user_data)
 
+    
     def get_user_data(self):
         '''Get media descriptor's user_data. user_data is specialized data
         accessed by the host application, VLC.framework uses it as a pointer to
@@ -1962,20 +2304,18 @@ class Media(_Ctype):
         '''
         return libvlc_media_get_user_data(self)
 
-    def tracks_get(self, tracks):
-        '''Get media descriptor's elementary streams description
-        Note, you need to call L{parse}() or play the media at least once
-        before calling this function.
-        Not doing this will result in an empty array.
-        @param tracks: address to store an allocated array of Elementary Streams descriptions (must be freed with L{tracks_release}.
-        @return: the number of Elementary Streams (zero on error).
-        @version: LibVLC 2.1.0 and later.
+    
+    def get_type(self):
+        '''Get the media type of the media descriptor object.
+        @return: media type.
+        @version: LibVLC 3.0.0 and later. See libvlc_media_type_t.
         '''
-        return libvlc_media_tracks_get(self, tracks)
+        return libvlc_media_get_type(self)
 
+    
     def player_new_from_media(self):
         '''Create a Media Player object from a Media.
-        @return: a new media player object, or NULL on error.
+        @return: a new media player object, or None on error.
         '''
         return libvlc_media_player_new_from_media(self)
 
@@ -1987,30 +2327,54 @@ class MediaDiscoverer(_Ctype):
         '''(INTERNAL) ctypes wrapper constructor.
         '''
         return _Constructor(cls, ptr)
+    
+    def start(self):
+        '''Start media discovery.
+        To stop it, call L{stop}() or
+        L{release}() directly.
+        See L{stop}.
+        @return: -1 in case of error, 0 otherwise.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_media_discoverer_start(self)
+
+    
+    def stop(self):
+        '''Stop media discovery.
+        See L{start}.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_media_discoverer_stop(self)
+
+    
     def release(self):
         '''Release media discover object. If the reference count reaches 0, then
         the object will be released.
         '''
         return libvlc_media_discoverer_release(self)
 
+    
     def localized_name(self):
         '''Get media service discover object its localized name.
         @return: localized name.
         '''
         return libvlc_media_discoverer_localized_name(self)
 
+    
     def media_list(self):
         '''Get media service discover media list.
         @return: list of media items.
         '''
         return libvlc_media_discoverer_media_list(self)
 
+    @memoize_parameterless
     def event_manager(self):
         '''Get event manager from media service discover object.
         @return: event manager object.
         '''
         return libvlc_media_discoverer_event_manager(self)
 
+    
     def is_running(self):
         '''Query if media service discover object is running.
         @return: true if running, false if not \libvlc_return_bool.
@@ -2025,6 +2389,7 @@ class MediaLibrary(_Ctype):
         '''(INTERNAL) ctypes wrapper constructor.
         '''
         return _Constructor(cls, ptr)
+    
     def release(self):
         '''Release media library object. This functions decrements the
         reference count of the media library object. If it reaches 0,
@@ -2032,6 +2397,7 @@ class MediaLibrary(_Ctype):
         '''
         return libvlc_media_library_release(self)
 
+    
     def retain(self):
         '''Retain a reference to a media library object. This function will
         increment the reference counting for this object. Use
@@ -2039,12 +2405,14 @@ class MediaLibrary(_Ctype):
         '''
         return libvlc_media_library_retain(self)
 
+    
     def load(self):
         '''Load media library.
         @return: 0 on success, -1 on error.
         '''
         return libvlc_media_library_load(self)
 
+    
     def media_list(self):
         '''Get media library subitems.
         @return: media list subitems.
@@ -2086,16 +2454,19 @@ class MediaList(_Ctype):
         return libvlc_media_list_add_media(self, mrl)
 
 
+    
     def release(self):
         '''Release media list created with L{new}().
         '''
         return libvlc_media_list_release(self)
 
+    
     def retain(self):
         '''Retain reference to a media list.
         '''
         return libvlc_media_list_retain(self)
 
+    
     def set_media(self, p_md):
         '''Associate media instance with this media list instance.
         If another media instance was present it will be released.
@@ -2104,6 +2475,7 @@ class MediaList(_Ctype):
         '''
         return libvlc_media_list_set_media(self, p_md)
 
+    
     def media(self):
         '''Get media instance from this media list instance. This action will increase
         the refcount on the media instance.
@@ -2112,6 +2484,7 @@ class MediaList(_Ctype):
         '''
         return libvlc_media_list_media(self)
 
+    
     def insert_media(self, p_md, i_pos):
         '''Insert media instance in media list on a position
         The L{lock} should be held upon entering this function.
@@ -2121,6 +2494,7 @@ class MediaList(_Ctype):
         '''
         return libvlc_media_list_insert_media(self, p_md, i_pos)
 
+    
     def remove_index(self, i_pos):
         '''Remove media instance from media list on a position
         The L{lock} should be held upon entering this function.
@@ -2129,6 +2503,7 @@ class MediaList(_Ctype):
         '''
         return libvlc_media_list_remove_index(self, i_pos)
 
+    
     def count(self):
         '''Get count on media list items
         The L{lock} should be held upon entering this function.
@@ -2139,11 +2514,12 @@ class MediaList(_Ctype):
     def __len__(self):
         return libvlc_media_list_count(self)
 
+    
     def item_at_index(self, i_pos):
         '''List media instance in media list at a position
         The L{lock} should be held upon entering this function.
         @param i_pos: position in array where to insert.
-        @return: media instance at position i_pos, or NULL if not found. In case of success, L{media_retain}() is called to increase the refcount on the media.
+        @return: media instance at position i_pos, or None if not found. In case of success, L{media_retain}() is called to increase the refcount on the media.
         '''
         return libvlc_media_list_item_at_index(self, i_pos)
 
@@ -2154,6 +2530,7 @@ class MediaList(_Ctype):
         for i in range(len(self)):
             yield self[i]
 
+    
     def index_of_item(self, p_md):
         '''Find index position of List media instance in media list.
         Warning: the function will return the first matched position.
@@ -2163,23 +2540,27 @@ class MediaList(_Ctype):
         '''
         return libvlc_media_list_index_of_item(self, p_md)
 
+    
     def is_readonly(self):
         '''This indicates if this media list is read-only from a user point of view.
         @return: 1 on readonly, 0 on readwrite \libvlc_return_bool.
         '''
         return libvlc_media_list_is_readonly(self)
 
+    
     def lock(self):
         '''Get lock on media list items.
         '''
         return libvlc_media_list_lock(self)
 
+    
     def unlock(self):
         '''Release lock on media list items
         The L{lock} should be held upon entering this function.
         '''
         return libvlc_media_list_unlock(self)
 
+    @memoize_parameterless
     def event_manager(self):
         '''Get libvlc_event_manager from this media list instance.
         The p_event_manager is immutable, so you don't have to hold the lock.
@@ -2214,6 +2595,7 @@ class MediaListPlayer(_Ctype):
         return self._instance  #PYCHOK expected
 
 
+    
     def release(self):
         '''Release a media_list_player after use
         Decrement the reference count of a media player object. If the
@@ -2223,52 +2605,61 @@ class MediaListPlayer(_Ctype):
         '''
         return libvlc_media_list_player_release(self)
 
+    
     def retain(self):
         '''Retain a reference to a media player list object. Use
         L{release}() to decrement reference count.
         '''
         return libvlc_media_list_player_retain(self)
 
+    @memoize_parameterless
     def event_manager(self):
         '''Return the event manager of this media_list_player.
         @return: the event manager.
         '''
         return libvlc_media_list_player_event_manager(self)
 
+    
     def set_media_player(self, p_mi):
         '''Replace media player in media_list_player with this instance.
         @param p_mi: media player instance.
         '''
         return libvlc_media_list_player_set_media_player(self, p_mi)
 
+    
     def set_media_list(self, p_mlist):
         '''Set the media list associated with the player.
         @param p_mlist: list of media.
         '''
         return libvlc_media_list_player_set_media_list(self, p_mlist)
 
+    
     def play(self):
         '''Play media list.
         '''
         return libvlc_media_list_player_play(self)
 
+    
     def pause(self):
         '''Toggle pause (or resume) media list.
         '''
         return libvlc_media_list_player_pause(self)
 
+    
     def is_playing(self):
         '''Is media list playing?
         @return: true for playing and false for not playing \libvlc_return_bool.
         '''
         return libvlc_media_list_player_is_playing(self)
 
+    
     def get_state(self):
         '''Get current libvlc_state of media list player.
         @return: libvlc_state_t for media list player.
         '''
         return libvlc_media_list_player_get_state(self)
 
+    
     def play_item_at_index(self, i_index):
         '''Play media list item at position index.
         @param i_index: index in media list to play.
@@ -2283,6 +2674,7 @@ class MediaListPlayer(_Ctype):
         for i in range(len(self)):
             yield self[i]
 
+    
     def play_item(self, p_md):
         '''Play the given media item.
         @param p_md: the media instance.
@@ -2290,23 +2682,27 @@ class MediaListPlayer(_Ctype):
         '''
         return libvlc_media_list_player_play_item(self, p_md)
 
+    
     def stop(self):
         '''Stop playing media list.
         '''
         return libvlc_media_list_player_stop(self)
 
+    
     def next(self):
         '''Play next item from media list.
         @return: 0 upon success -1 if there is no next item.
         '''
         return libvlc_media_list_player_next(self)
 
+    
     def previous(self):
         '''Play previous item from media list.
         @return: 0 upon success -1 if there is no previous item.
         '''
         return libvlc_media_list_player_previous(self)
 
+    
     def set_playback_mode(self, e_mode):
         '''Sets the playback mode for the playlist.
         @param e_mode: playback mode specification.
@@ -2345,6 +2741,10 @@ class MediaPlayer(_Ctype):
     def set_mrl(self, mrl, *options):
         """Set the MRL to play.
 
+        Warning: most audio and video options, such as text renderer,
+        have no effects on an individual media. These options must be
+        set at the vlc.Instance or vlc.MediaPlayer instanciation.
+
         @param mrl: The MRL
         @param options: optional media option=value strings
         @return: the Media object
@@ -2379,6 +2779,27 @@ class MediaPlayer(_Ctype):
         """Get the description of available audio tracks.
         """
         return track_description_list(libvlc_audio_get_track_description(self))
+
+    def get_full_title_descriptions(self):
+        '''Get the full description of available titles.
+        @return: the titles list
+        @version: LibVLC 3.0.0 and later.
+        '''
+        titleDescription_pp = ctypes.POINTER(TitleDescription)()
+        n = libvlc_media_player_get_full_title_descriptions(self, ctypes.byref(titleDescription_pp))
+        info = ctypes.cast(ctypes.titleDescription_pp, ctypes.POINTER(ctypes.POINTER(TitleDescription) * n))
+        return info
+
+    def get_full_chapter_descriptions(self, i_chapters_of_title):
+        '''Get the full description of available chapters.
+        @param index: of the title to query for chapters.
+        @return: the chapter list
+        @version: LibVLC 3.0.0 and later.
+        '''
+        chapterDescription_pp = ctypes.POINTER(ChapterDescription)()
+        n = libvlc_media_player_get_full_chapter_descriptions(self, ctypes.byref(chapterDescription_pp))
+        info = ctypes.cast(ctypes.chapterDescription_pp, ctypes.POINTER(ctypes.POINTER(ChapterDescription) * n))
+        return info
 
     def video_get_size(self, num=0):
         """Get the video size in pixels as 2-tuple (width, height).
@@ -2443,6 +2864,7 @@ class MediaPlayer(_Ctype):
         raise VLCException('invalid video number (%s)' % (num,))
 
 
+    
     def release(self):
         '''Release a media_player after use
         Decrement the reference count of a media player object. If the
@@ -2452,12 +2874,14 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_release(self)
 
+    
     def retain(self):
         '''Retain a reference to a media player object. Use
         L{release}() to decrement reference count.
         '''
         return libvlc_media_player_retain(self)
 
+    
     def set_media(self, p_md):
         '''Set the media that will be used by the media_player. If any,
         previous md will be released.
@@ -2465,30 +2889,35 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_media(self, p_md)
 
+    
     def get_media(self):
         '''Get the media used by the media_player.
-        @return: the media associated with p_mi, or NULL if no media is associated.
+        @return: the media associated with p_mi, or None if no media is associated.
         '''
         return libvlc_media_player_get_media(self)
 
+    @memoize_parameterless
     def event_manager(self):
         '''Get the Event Manager from which the media player send event.
         @return: the event manager associated with p_mi.
         '''
         return libvlc_media_player_event_manager(self)
 
+    
     def is_playing(self):
         '''is_playing.
         @return: 1 if the media player is playing, 0 otherwise \libvlc_return_bool.
         '''
         return libvlc_media_player_is_playing(self)
 
+    
     def play(self):
         '''Play.
         @return: 0 if playback started (and was already started), or -1 on error.
         '''
         return libvlc_media_player_play(self)
 
+    
     def set_pause(self, do_pause):
         '''Pause or resume (no effect if there is no media).
         @param do_pause: play/resume if zero, pause if non-zero.
@@ -2496,29 +2925,33 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_pause(self, do_pause)
 
+    
     def pause(self):
         '''Toggle pause (no effect if there is no media).
         '''
         return libvlc_media_player_pause(self)
 
+    
     def stop(self):
         '''Stop (no effect if there is no media).
         '''
         return libvlc_media_player_stop(self)
 
+    
     def video_set_callbacks(self, lock, unlock, display, opaque):
         '''Set callbacks and private data to render decoded video to a custom area
         in memory.
         Use L{video_set_format}() or L{video_set_format_callbacks}()
         to configure the decoded format.
-        @param lock: callback to lock video memory (must not be NULL).
-        @param unlock: callback to unlock video memory (or NULL if not needed).
-        @param display: callback to display video (or NULL if not needed).
+        @param lock: callback to lock video memory (must not be None).
+        @param unlock: callback to unlock video memory (or None if not needed).
+        @param display: callback to display video (or None if not needed).
         @param opaque: private pointer for the three callbacks (as first parameter).
         @version: LibVLC 1.1.1 or later.
         '''
         return libvlc_video_set_callbacks(self, lock, unlock, display, opaque)
 
+    
     def video_set_format(self, chroma, width, height, pitch):
         '''Set decoded video chroma and dimensions.
         This only works in combination with L{video_set_callbacks}(),
@@ -2532,21 +2965,23 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_format(self, str_to_bytes(chroma), width, height, pitch)
 
+    
     def video_set_format_callbacks(self, setup, cleanup):
         '''Set decoded video chroma and dimensions. This only works in combination with
         L{video_set_callbacks}().
-        @param setup: callback to select the video format (cannot be NULL).
-        @param cleanup: callback to release any allocated resources (or NULL).
+        @param setup: callback to select the video format (cannot be None).
+        @param cleanup: callback to release any allocated resources (or None).
         @version: LibVLC 2.0.0 or later.
         '''
         return libvlc_video_set_format_callbacks(self, setup, cleanup)
 
+    
     def set_nsobject(self, drawable):
         '''Set the NSView handler where the media player should render its video output.
         Use the vout called "macosx".
         The drawable is an NSObject that follow the VLCOpenGLVideoViewEmbedding
         protocol:
-        @begincode
+        @code.m
         \@protocol VLCOpenGLVideoViewEmbedding <NSObject>
         - (void)addVoutSubview:(NSView *)view;
         - (void)removeVoutSubview:(NSView *)view;
@@ -2555,7 +2990,7 @@ class MediaPlayer(_Ctype):
         Or it can be an NSView object.
         If you want to use it along with Qt4 see the QMacCocoaViewContainer. Then
         the following code should work:
-        @begincode
+        @code.mm
         
             NSView *video = [[NSView alloc] init];
             QMacCocoaViewContainer *container = new QMacCocoaViewContainer(video, parent);
@@ -2568,24 +3003,28 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_nsobject(self, drawable)
 
+    
     def get_nsobject(self):
         '''Get the NSView handler previously set with L{set_nsobject}().
         @return: the NSView handler or 0 if none where set.
         '''
         return libvlc_media_player_get_nsobject(self)
 
+    
     def set_agl(self, drawable):
         '''Set the agl handler where the media player should render its video output.
         @param drawable: the agl handler.
         '''
         return libvlc_media_player_set_agl(self, drawable)
 
+    
     def get_agl(self):
         '''Get the agl handler previously set with L{set_agl}().
         @return: the agl handler or 0 if none where set.
         '''
         return libvlc_media_player_get_agl(self)
 
+    
     def set_xwindow(self, drawable):
         '''Set an X Window System drawable where the media player should render its
         video output. If LibVLC was built without X11 output support, then this has
@@ -2599,6 +3038,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_xwindow(self, drawable)
 
+    
     def get_xwindow(self):
         '''Get the X Window System window identifier previously set with
         L{set_xwindow}(). Note that this will return the identifier
@@ -2608,46 +3048,52 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_get_xwindow(self)
 
+    
     def get_hwnd(self):
         '''Get the Windows API window handle (HWND) previously set with
         L{set_hwnd}(). The handle will be returned even if LibVLC
         is not currently outputting any video to it.
-        @return: a window handle or NULL if there are none.
+        @return: a window handle or None if there are none.
         '''
         return libvlc_media_player_get_hwnd(self)
 
+    
     def audio_set_callbacks(self, play, pause, resume, flush, drain, opaque):
         '''Set callbacks and private data for decoded audio.
         Use L{audio_set_format}() or L{audio_set_format_callbacks}()
         to configure the decoded audio format.
-        @param play: callback to play audio samples (must not be NULL).
-        @param pause: callback to pause playback (or NULL to ignore).
-        @param resume: callback to resume playback (or NULL to ignore).
-        @param flush: callback to flush audio buffers (or NULL to ignore).
-        @param drain: callback to drain audio buffers (or NULL to ignore).
+        @param play: callback to play audio samples (must not be None).
+        @param pause: callback to pause playback (or None to ignore).
+        @param resume: callback to resume playback (or None to ignore).
+        @param flush: callback to flush audio buffers (or None to ignore).
+        @param drain: callback to drain audio buffers (or None to ignore).
         @param opaque: private pointer for the audio callbacks (as first parameter).
         @version: LibVLC 2.0.0 or later.
         '''
         return libvlc_audio_set_callbacks(self, play, pause, resume, flush, drain, opaque)
 
+    
     def audio_set_volume_callback(self, set_volume):
-        '''Set callbacks and private data for decoded audio.
+        '''Set callbacks and private data for decoded audio. This only works in
+        combination with L{audio_set_callbacks}().
         Use L{audio_set_format}() or L{audio_set_format_callbacks}()
         to configure the decoded audio format.
-        @param set_volume: callback to apply audio volume, or NULL to apply volume in software.
+        @param set_volume: callback to apply audio volume, or None to apply volume in software.
         @version: LibVLC 2.0.0 or later.
         '''
         return libvlc_audio_set_volume_callback(self, set_volume)
 
+    
     def audio_set_format_callbacks(self, setup, cleanup):
         '''Set decoded audio format. This only works in combination with
         L{audio_set_callbacks}().
-        @param setup: callback to select the audio format (cannot be NULL).
-        @param cleanup: callback to release any allocated resources (or NULL).
+        @param setup: callback to select the audio format (cannot be None).
+        @param cleanup: callback to release any allocated resources (or None).
         @version: LibVLC 2.0.0 or later.
         '''
         return libvlc_audio_set_format_callbacks(self, setup, cleanup)
 
+    
     def audio_set_format(self, format, rate, channels):
         '''Set decoded audio format.
         This only works in combination with L{audio_set_callbacks}(),
@@ -2659,18 +3105,21 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_audio_set_format(self, str_to_bytes(format), rate, channels)
 
+    
     def get_length(self):
         '''Get the current movie length (in ms).
         @return: the movie length (in ms), or -1 if there is no media.
         '''
         return libvlc_media_player_get_length(self)
 
+    
     def get_time(self):
         '''Get the current movie time (in ms).
         @return: the movie time (in ms), or -1 if there is no media.
         '''
         return libvlc_media_player_get_time(self)
 
+    
     def set_time(self, i_time):
         '''Set the movie time (in ms). This has no effect if no media is being played.
         Not all formats and protocols support this.
@@ -2678,12 +3127,14 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_time(self, i_time)
 
+    
     def get_position(self):
         '''Get movie position as percentage between 0.0 and 1.0.
         @return: movie position, or -1. in case of error.
         '''
         return libvlc_media_player_get_position(self)
 
+    
     def set_position(self, f_pos):
         '''Set movie position as percentage between 0.0 and 1.0.
         This has no effect if playback is not enabled.
@@ -2692,30 +3143,35 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_position(self, f_pos)
 
+    
     def set_chapter(self, i_chapter):
         '''Set movie chapter (if applicable).
         @param i_chapter: chapter number to play.
         '''
         return libvlc_media_player_set_chapter(self, i_chapter)
 
+    
     def get_chapter(self):
         '''Get movie chapter.
         @return: chapter number currently playing, or -1 if there is no media.
         '''
         return libvlc_media_player_get_chapter(self)
 
+    
     def get_chapter_count(self):
         '''Get movie chapter count.
         @return: number of chapters in movie, or -1.
         '''
         return libvlc_media_player_get_chapter_count(self)
 
+    
     def will_play(self):
         '''Is the player able to play.
         @return: boolean \libvlc_return_bool.
         '''
         return libvlc_media_player_will_play(self)
 
+    
     def get_chapter_count_for_title(self, i_title):
         '''Get title chapter count.
         @param i_title: title.
@@ -2723,34 +3179,40 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_get_chapter_count_for_title(self, i_title)
 
+    
     def set_title(self, i_title):
         '''Set movie title.
         @param i_title: title number to play.
         '''
         return libvlc_media_player_set_title(self, i_title)
 
+    
     def get_title(self):
         '''Get movie title.
         @return: title number currently playing, or -1.
         '''
         return libvlc_media_player_get_title(self)
 
+    
     def get_title_count(self):
         '''Get movie title count.
         @return: title number count, or -1.
         '''
         return libvlc_media_player_get_title_count(self)
 
+    
     def previous_chapter(self):
         '''Set previous chapter (if applicable).
         '''
         return libvlc_media_player_previous_chapter(self)
 
+    
     def next_chapter(self):
         '''Set next chapter (if applicable).
         '''
         return libvlc_media_player_next_chapter(self)
 
+    
     def get_rate(self):
         '''Get the requested movie play rate.
         @warning: Depending on the underlying media, the requested rate may be
@@ -2759,6 +3221,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_get_rate(self)
 
+    
     def set_rate(self, rate):
         '''Set movie play rate.
         @param rate: movie play rate to set.
@@ -2766,41 +3229,56 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_set_rate(self, rate)
 
+    
     def get_state(self):
         '''Get current movie state.
         @return: the current state of the media player (playing, paused, ...) See libvlc_state_t.
         '''
         return libvlc_media_player_get_state(self)
 
+    
     def get_fps(self):
         '''Get movie fps rate.
         @return: frames per second (fps) for this playing movie, or 0 if unspecified.
         '''
         return libvlc_media_player_get_fps(self)
 
+    
     def has_vout(self):
         '''How many video outputs does this media player have?
         @return: the number of video outputs.
         '''
         return libvlc_media_player_has_vout(self)
 
+    
     def is_seekable(self):
         '''Is this media player seekable?
         @return: true if the media player can seek \libvlc_return_bool.
         '''
         return libvlc_media_player_is_seekable(self)
 
+    
     def can_pause(self):
         '''Can this media player be paused?
         @return: true if the media player can pause \libvlc_return_bool.
         '''
         return libvlc_media_player_can_pause(self)
 
+    
+    def program_scrambled(self):
+        '''Check if the current program is scrambled.
+        @return: true if the current program is scrambled \libvlc_return_bool.
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_media_player_program_scrambled(self)
+
+    
     def next_frame(self):
         '''Display the next frame (if supported).
         '''
         return libvlc_media_player_next_frame(self)
 
+    
     def navigate(self, navigate):
         '''Navigate through DVD Menu.
         @param navigate: the Navigation mode.
@@ -2808,6 +3286,16 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_media_player_navigate(self, navigate)
 
+    
+    def set_video_title_display(self, position, timeout):
+        '''Set if, and how, the video title will be shown when media is played.
+        @param position: position at which to display the title, or libvlc_position_disable to prevent the title from being displayed.
+        @param timeout: title display timeout in milliseconds (ignored if libvlc_position_disable).
+        @version: libVLC 2.1.0 or later.
+        '''
+        return libvlc_media_player_set_video_title_display(self, position, timeout)
+
+    
     def toggle_fullscreen(self):
         '''Toggle fullscreen status on non-embedded video outputs.
         @warning: The same limitations applies to this function
@@ -2815,6 +3303,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_toggle_fullscreen(self)
 
+    
     def set_fullscreen(self, b_fullscreen):
         '''Enable or disable fullscreen.
         @warning: With most window managers, only a top-level windows can be in
@@ -2827,12 +3316,14 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_set_fullscreen(self, b_fullscreen)
 
+    
     def get_fullscreen(self):
         '''Get current fullscreen status.
         @return: the fullscreen status (boolean) \libvlc_return_bool.
         '''
         return libvlc_get_fullscreen(self)
 
+    
     def video_set_key_input(self, on):
         '''Enable or disable key press events handling, according to the LibVLC hotkeys
         configuration. By default and for historical reasons, keyboard events are
@@ -2846,6 +3337,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_key_input(self, on)
 
+    
     def video_set_mouse_input(self, on):
         '''Enable or disable mouse click events handling. By default, those events are
         handled. This is needed for DVD menus to work, as well as a few video
@@ -2856,6 +3348,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_mouse_input(self, on)
 
+    
     def video_get_scale(self):
         '''Get the current video scaling factor.
         See also L{video_set_scale}().
@@ -2863,6 +3356,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_get_scale(self)
 
+    
     def video_set_scale(self, f_factor):
         '''Set the video scaling factor. That is the ratio of the number of pixels on
         screen to the number of pixels in the original decoded video in each
@@ -2873,30 +3367,35 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_scale(self, f_factor)
 
+    
     def video_get_aspect_ratio(self):
         '''Get current video aspect ratio.
-        @return: the video aspect ratio or NULL if unspecified (the result must be released with free() or L{free}()).
+        @return: the video aspect ratio or None if unspecified (the result must be released with free() or L{free}()).
         '''
         return libvlc_video_get_aspect_ratio(self)
 
+    
     def video_set_aspect_ratio(self, psz_aspect):
         '''Set new video aspect ratio.
-        @param psz_aspect: new video aspect-ratio or NULL to reset to default @note Invalid aspect ratios are ignored.
+        @param psz_aspect: new video aspect-ratio or None to reset to default @note Invalid aspect ratios are ignored.
         '''
         return libvlc_video_set_aspect_ratio(self, str_to_bytes(psz_aspect))
 
+    
     def video_get_spu(self):
         '''Get current video subtitle.
         @return: the video subtitle selected, or -1 if none.
         '''
         return libvlc_video_get_spu(self)
 
+    
     def video_get_spu_count(self):
         '''Get the number of available video subtitles.
         @return: the number of available video subtitles.
         '''
         return libvlc_video_get_spu_count(self)
 
+    
     def video_set_spu(self, i_spu):
         '''Set new video subtitle.
         @param i_spu: video subtitle track to select (i_id from track description).
@@ -2904,6 +3403,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_spu(self, i_spu)
 
+    
     def video_set_subtitle_file(self, psz_subtitle):
         '''Set new video subtitle file.
         @param psz_subtitle: new video subtitle file.
@@ -2911,6 +3411,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_subtitle_file(self, str_to_bytes(psz_subtitle))
 
+    
     def video_get_spu_delay(self):
         '''Get the current subtitle delay. Positive values means subtitles are being
         displayed later, negative values earlier.
@@ -2919,6 +3420,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_get_spu_delay(self)
 
+    
     def video_set_spu_delay(self, i_delay):
         '''Set the subtitle delay. This affects the timing of when the subtitle will
         be displayed. Positive values result in subtitles being displayed later,
@@ -2930,47 +3432,55 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_spu_delay(self, i_delay)
 
+    
     def video_get_crop_geometry(self):
         '''Get current crop filter geometry.
-        @return: the crop filter geometry or NULL if unset.
+        @return: the crop filter geometry or None if unset.
         '''
         return libvlc_video_get_crop_geometry(self)
 
+    
     def video_set_crop_geometry(self, psz_geometry):
         '''Set new crop filter geometry.
-        @param psz_geometry: new crop filter geometry (NULL to unset).
+        @param psz_geometry: new crop filter geometry (None to unset).
         '''
         return libvlc_video_set_crop_geometry(self, str_to_bytes(psz_geometry))
 
+    
     def video_get_teletext(self):
         '''Get current teletext page requested.
         @return: the current teletext page requested.
         '''
         return libvlc_video_get_teletext(self)
 
+    
     def video_set_teletext(self, i_page):
         '''Set new teletext page to retrieve.
         @param i_page: teletex page number requested.
         '''
         return libvlc_video_set_teletext(self, i_page)
 
+    
     def toggle_teletext(self):
         '''Toggle teletext transparent status on video output.
         '''
         return libvlc_toggle_teletext(self)
 
+    
     def video_get_track_count(self):
         '''Get number of available video tracks.
         @return: the number of available video tracks (int).
         '''
         return libvlc_video_get_track_count(self)
 
+    
     def video_get_track(self):
         '''Get current video track.
         @return: the video track ID (int) or -1 if no active input.
         '''
         return libvlc_video_get_track(self)
 
+    
     def video_set_track(self, i_track):
         '''Set video track.
         @param i_track: the track ID (i_id field from track description).
@@ -2978,6 +3488,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_track(self, i_track)
 
+    
     def video_take_snapshot(self, num, psz_filepath, i_width, i_height):
         '''Take a snapshot of the current video window.
         If i_width AND i_height is 0, original size is used.
@@ -2990,24 +3501,28 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_take_snapshot(self, num, str_to_bytes(psz_filepath), i_width, i_height)
 
+    
     def video_set_deinterlace(self, psz_mode):
         '''Enable or disable deinterlace filter.
-        @param psz_mode: type of deinterlace filter, NULL to disable.
+        @param psz_mode: type of deinterlace filter, None to disable.
         '''
         return libvlc_video_set_deinterlace(self, str_to_bytes(psz_mode))
 
+    
     def video_get_marquee_int(self, option):
         '''Get an integer marquee option value.
         @param option: marq option to get See libvlc_video_marquee_int_option_t.
         '''
         return libvlc_video_get_marquee_int(self, option)
 
+    
     def video_get_marquee_string(self, option):
         '''Get a string marquee option value.
         @param option: marq option to get See libvlc_video_marquee_string_option_t.
         '''
         return libvlc_video_get_marquee_string(self, option)
 
+    
     def video_set_marquee_int(self, option, i_val):
         '''Enable, disable or set an integer marquee option
         Setting libvlc_marquee_Enable has the side effect of enabling (arg !0)
@@ -3017,6 +3532,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_marquee_int(self, option, i_val)
 
+    
     def video_set_marquee_string(self, option, psz_text):
         '''Set a marquee string option.
         @param option: marq option to set See libvlc_video_marquee_string_option_t.
@@ -3024,12 +3540,14 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_marquee_string(self, option, str_to_bytes(psz_text))
 
+    
     def video_get_logo_int(self, option):
         '''Get integer logo option.
         @param option: logo option to get, values of libvlc_video_logo_option_t.
         '''
         return libvlc_video_get_logo_int(self, option)
 
+    
     def video_set_logo_int(self, option, value):
         '''Set logo option as integer. Options that take a different type value
         are ignored.
@@ -3040,6 +3558,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_logo_int(self, option, value)
 
+    
     def video_set_logo_string(self, option, psz_value):
         '''Set logo option as string. Options that take a different type value
         are ignored.
@@ -3048,6 +3567,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_logo_string(self, option, str_to_bytes(psz_value))
 
+    
     def video_get_adjust_int(self, option):
         '''Get integer adjust option.
         @param option: adjust option to get, values of libvlc_video_adjust_option_t.
@@ -3055,6 +3575,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_get_adjust_int(self, option)
 
+    
     def video_set_adjust_int(self, option, value):
         '''Set adjust option as integer. Options that take a different type value
         are ignored.
@@ -3066,6 +3587,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_adjust_int(self, option, value)
 
+    
     def video_get_adjust_float(self, option):
         '''Get float adjust option.
         @param option: adjust option to get, values of libvlc_video_adjust_option_t.
@@ -3073,6 +3595,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_get_adjust_float(self, option)
 
+    
     def video_set_adjust_float(self, option, value):
         '''Set adjust option as float. Options that take a different type value
         are ignored.
@@ -3082,8 +3605,9 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_video_set_adjust_float(self, option, value)
 
+    
     def audio_output_set(self, psz_name):
-        '''Sets the audio output.
+        '''Selects an audio output module.
         @note: Any change will take be effect only after playback is stopped and
         restarted. Audio output cannot be changed while playing.
         @param psz_name: name of audio output, use psz_name of See L{AudioOutput}.
@@ -3091,45 +3615,95 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_audio_output_set(self, str_to_bytes(psz_name))
 
-    def audio_output_device_set(self, psz_audio_output, psz_device_id):
-        '''Configures an explicit audio output device for a given audio output plugin.
-        A list of possible devices can be obtained with
+    
+    def audio_output_device_enum(self):
+        '''Gets a list of potential audio output devices,
+        See L{audio_output_device_set}().
+        @note: Not all audio outputs support enumerating devices.
+        The audio output may be functional even if the list is empty (None).
+        @note: The list may not be exhaustive.
+        @warning: Some audio output devices in the list might not actually work in
+        some circumstances. By default, it is recommended to not specify any
+        explicit audio device.
+        @return: A None-terminated linked list of potential audio output devices. It must be freed with L{audio_output_device_list_release}().
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_audio_output_device_enum(self)
+
+    
+    def audio_output_device_set(self, module, device_id):
+        '''Configures an explicit audio output device.
+        If the module paramater is None, audio output will be moved to the device
+        specified by the device identifier string immediately. This is the
+        recommended usage.
+        A list of adequate potential device strings can be obtained with
+        L{audio_output_device_enum}().
+        However passing None is supported in LibVLC version 2.2.0 and later only;
+        in earlier versions, this function would have no effects when the module
+        parameter was None.
+        If the module parameter is not None, the device parameter of the
+        corresponding audio output, if it exists, will be set to the specified
+        string. Note that some audio output modules do not have such a parameter
+        (notably MMDevice and PulseAudio).
+        A list of adequate potential device strings can be obtained with
         L{audio_output_device_list_get}().
         @note: This function does not select the specified audio output plugin.
         L{audio_output_set}() is used for that purpose.
         @warning: The syntax for the device parameter depends on the audio output.
-        This is not portable. Only use this function if you know what you are doing.
-        Some audio outputs do not support this function (e.g. PulseAudio, WASAPI).
-        Some audio outputs require further parameters (e.g. ALSA: channels map).
-        @param psz_audio_output: - name of audio output, See L{AudioOutput}.
-        @param psz_device_id: device.
-        @return: Nothing. Errors are ignored.
+        Some audio output modules require further parameters (e.g. a channels map
+        in the case of ALSA).
+        @param module: If None, current audio output module. if non-None, name of audio output module.
+        @param device_id: device identifier string.
+        @return: Nothing. Errors are ignored (this is a design bug).
         '''
-        return libvlc_audio_output_device_set(self, str_to_bytes(psz_audio_output), str_to_bytes(psz_device_id))
+        return libvlc_audio_output_device_set(self, str_to_bytes(module), str_to_bytes(device_id))
 
+    
+    def audio_output_device_get(self):
+        '''Get the current audio output device identifier.
+        This complements L{audio_output_device_set}().
+        @warning: The initial value for the current audio output device identifier
+        may not be set or may be some unknown value. A LibVLC application should
+        compare this value against the known device identifiers (e.g. those that
+        were previously retrieved by a call to L{audio_output_device_enum} or
+        L{audio_output_device_list_get}) to find the current audio output device.
+        It is possible that the selected audio output device changes (an external
+        change) without a call to L{audio_output_device_set}. That may make this
+        method unsuitable to use if a LibVLC application is attempting to track
+        dynamic audio device changes as they happen.
+        @return: the current audio output device identifier None if no device is selected or in case of error (the result must be released with free() or L{free}()).
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_audio_output_device_get(self)
+
+    
     def audio_toggle_mute(self):
         '''Toggle mute status.
         '''
         return libvlc_audio_toggle_mute(self)
 
+    
     def audio_get_mute(self):
         '''Get current mute status.
         @return: the mute status (boolean) if defined, -1 if undefined/unapplicable.
         '''
         return libvlc_audio_get_mute(self)
 
+    
     def audio_set_mute(self, status):
         '''Set mute status.
         @param status: If status is true then mute, otherwise unmute @warning This function does not always work. If there are no active audio playback stream, the mute status might not be available. If digital pass-through (S/PDIF, HDMI...) is in use, muting may be unapplicable. Also some audio output plugins do not support muting at all. @note To force silent playback, disable all audio tracks. This is more efficient and reliable than mute.
         '''
         return libvlc_audio_set_mute(self, status)
 
+    
     def audio_get_volume(self):
         '''Get current software audio volume.
         @return: the software volume in percents (0 = mute, 100 = nominal / 0dB).
         '''
         return libvlc_audio_get_volume(self)
 
+    
     def audio_set_volume(self, i_volume):
         '''Set current software audio volume.
         @param i_volume: the volume in percents (0 = mute, 100 = 0dB).
@@ -3137,18 +3711,21 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_audio_set_volume(self, i_volume)
 
+    
     def audio_get_track_count(self):
         '''Get number of available audio tracks.
         @return: the number of available audio tracks (int), or -1 if unavailable.
         '''
         return libvlc_audio_get_track_count(self)
 
+    
     def audio_get_track(self):
         '''Get current audio track.
         @return: the audio track ID or -1 if no active input.
         '''
         return libvlc_audio_get_track(self)
 
+    
     def audio_set_track(self, i_track):
         '''Set current audio track.
         @param i_track: the track ID (i_id field from track description).
@@ -3156,12 +3733,14 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_audio_set_track(self, i_track)
 
+    
     def audio_get_channel(self):
         '''Get current audio channel.
         @return: the audio channel See libvlc_audio_output_channel_t.
         '''
         return libvlc_audio_get_channel(self)
 
+    
     def audio_set_channel(self, channel):
         '''Set current audio channel.
         @param channel: the audio channel, See libvlc_audio_output_channel_t.
@@ -3169,6 +3748,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_audio_set_channel(self, channel)
 
+    
     def audio_get_delay(self):
         '''Get current audio delay.
         @return: the audio delay (microseconds).
@@ -3176,6 +3756,7 @@ class MediaPlayer(_Ctype):
         '''
         return libvlc_audio_get_delay(self)
 
+    
     def audio_set_delay(self, i_delay):
         '''Set current audio delay. The audio delay will be reset to zero each time the media changes.
         @param i_delay: the audio delay (microseconds).
@@ -3183,6 +3764,29 @@ class MediaPlayer(_Ctype):
         @version: LibVLC 1.1.1 or later.
         '''
         return libvlc_audio_set_delay(self, i_delay)
+
+    
+    def set_equalizer(self, p_equalizer):
+        '''Apply new equalizer settings to a media player.
+        The equalizer is first created by invoking L{audio_equalizer_new}() or
+        L{audio_equalizer_new_from_preset}().
+        It is possible to apply new equalizer settings to a media player whether the media
+        player is currently playing media or not.
+        Invoking this method will immediately apply the new equalizer settings to the audio
+        output of the currently playing media if there is any.
+        If there is no currently playing media, the new equalizer settings will be applied
+        later if and when new media is played.
+        Equalizer settings will automatically be applied to subsequently played media.
+        To disable the equalizer for a media player invoke this method passing None for the
+        p_equalizer parameter.
+        The media player does not keep a reference to the supplied equalizer so it is safe
+        for an application to release the equalizer reference any time after this method
+        returns.
+        @param p_equalizer: opaque equalizer handle, or None to disable the equalizer for this media player.
+        @return: zero on success, -1 on error.
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_media_player_set_equalizer(self, p_equalizer)
 
 
  # LibVLC __version__ functions #
@@ -3192,7 +3796,7 @@ def libvlc_errmsg():
     thread. The resulting string is valid until another error occurs (at least
     until the next LibVLC call).
     @warning
-    This will be NULL if there was no error.
+    This will be None if there was no error.
     '''
     f = _Cfunctions.get('libvlc_errmsg', None) or \
         _Cfunction('libvlc_errmsg', (), None,
@@ -3226,9 +3830,9 @@ def libvlc_new(argc, argv):
     This functions accept a list of "command line" arguments similar to the
     main(). These arguments affect the LibVLC instance default configuration.
     @param argc: the number of arguments (should be 0).
-    @param argv: list of arguments (should be NULL).
-    @return: the libvlc instance or NULL in case of error.
-    @version Arguments are meant to be passed from the command line to LibVLC, just like VLC media player does. The list of valid arguments depends on the LibVLC version, the operating system and platform, and set of available LibVLC plugins. Invalid or unsupported arguments will cause the function to fail (i.e. return NULL). Also, some arguments may alter the behaviour or otherwise interfere with other LibVLC functions. @warning There is absolutely no warranty or promise of forward, backward and cross-platform compatibility with regards to L{libvlc_new}() arguments. We recommend that you do not use them, other than when debugging.
+    @param argv: list of arguments (should be None).
+    @return: the libvlc instance or None in case of error.
+    @version Arguments are meant to be passed from the command line to LibVLC, just like VLC media player does. The list of valid arguments depends on the LibVLC version, the operating system and platform, and set of available LibVLC plugins. Invalid or unsupported arguments will cause the function to fail (i.e. return None). Also, some arguments may alter the behaviour or otherwise interfere with other LibVLC functions. @warning There is absolutely no warranty or promise of forward, backward and cross-platform compatibility with regards to L{libvlc_new}() arguments. We recommend that you do not use them, other than when debugging.
     '''
     f = _Cfunctions.get('libvlc_new', None) or \
         _Cfunction('libvlc_new', ((1,), (1,),), class_result(Instance),
@@ -3258,7 +3862,7 @@ def libvlc_retain(p_instance):
 def libvlc_add_intf(p_instance, name):
     '''Try to start a user interface for the libvlc instance.
     @param p_instance: the instance.
-    @param name: interface name, or NULL for default.
+    @param name: interface name, or None for default.
     @return: 0 on success, -1 on error.
     '''
     f = _Cfunctions.get('libvlc_add_intf', None) or \
@@ -3278,6 +3882,20 @@ def libvlc_set_user_agent(p_instance, name, http):
         _Cfunction('libvlc_set_user_agent', ((1,), (1,), (1,),), None,
                     None, Instance, ctypes.c_char_p, ctypes.c_char_p)
     return f(p_instance, name, http)
+
+def libvlc_set_app_id(p_instance, id, version, icon):
+    '''Sets some meta-information about the application.
+    See also L{libvlc_set_user_agent}().
+    @param p_instance: LibVLC instance.
+    @param id: Java-style application identifier, e.g. "com.acme.foobar".
+    @param version: application version numbers, e.g. "1.2.3".
+    @param icon: application icon name, e.g. "foobar".
+    @version: LibVLC 2.1.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_set_app_id', None) or \
+        _Cfunction('libvlc_set_app_id', ((1,), (1,), (1,), (1,),), None,
+                    None, Instance, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p)
+    return f(p_instance, id, version, icon)
 
 def libvlc_get_version():
     '''Retrieve libvlc version.
@@ -3355,12 +3973,12 @@ def libvlc_event_type_name(event_type):
     return f(event_type)
 
 def libvlc_log_get_context(ctx):
-    '''Gets debugging informations about a log message: the name of the VLC module
+    '''Gets debugging information about a log message: the name of the VLC module
     emitting the message and the message location within the source code.
-    The returned module name and file name will be NULL if unknown.
+    The returned module name and file name will be None if unknown.
     The returned line number will similarly be zero if unknown.
     @param ctx: message context (as passed to the @ref libvlc_log_cb callback).
-    @return: module module name storage (or NULL), file source code file name storage (or NULL), line source code file line number storage (or NULL).
+    @return: module module name storage (or None), file source code file name storage (or None), line source code file line number storage (or None).
     @version: LibVLC 2.1.0 or later.
     '''
     f = _Cfunctions.get('libvlc_log_get_context', None) or \
@@ -3369,17 +3987,17 @@ def libvlc_log_get_context(ctx):
     return f(ctx)
 
 def libvlc_log_get_object(ctx, id):
-    '''Gets VLC object informations about a log message: the type name of the VLC
+    '''Gets VLC object information about a log message: the type name of the VLC
     object emitting the message, the object header if any and a temporaly-unique
-    object identifier. These informations are mainly meant for B{manual}
+    object identifier. This information is mainly meant for B{manual}
     troubleshooting.
-    The returned type name may be "generic" if unknown, but it cannot be NULL.
-    The returned header will be NULL if unset; in current versions, the header
+    The returned type name may be "generic" if unknown, but it cannot be None.
+    The returned header will be None if unset; in current versions, the header
     is used to distinguish for VLM inputs.
     The returned object ID will be zero if the message is not associated with
     any VLC object.
     @param ctx: message context (as passed to the @ref libvlc_log_cb callback).
-    @return: name object name storage (or NULL), header object header (or NULL), line source code file line number storage (or NULL).
+    @return: name object name storage (or None), header object header (or None), line source code file line number storage (or None).
     @version: LibVLC 2.1.0 or later.
     '''
     f = _Cfunctions.get('libvlc_log_get_object', None) or \
@@ -3437,7 +4055,7 @@ def libvlc_module_description_list_release(p_list):
 def libvlc_audio_filter_list_get(p_instance):
     '''Returns a list of audio filters that are available.
     @param p_instance: libvlc instance.
-    @return: a list of module descriptions. It should be freed with L{libvlc_module_description_list_release}(). In case of an error, NULL is returned. See L{ModuleDescription} See L{libvlc_module_description_list_release}.
+    @return: a list of module descriptions. It should be freed with L{libvlc_module_description_list_release}(). In case of an error, None is returned. See L{ModuleDescription} See L{libvlc_module_description_list_release}.
     '''
     f = _Cfunctions.get('libvlc_audio_filter_list_get', None) or \
         _Cfunction('libvlc_audio_filter_list_get', ((1,),), None,
@@ -3447,7 +4065,7 @@ def libvlc_audio_filter_list_get(p_instance):
 def libvlc_video_filter_list_get(p_instance):
     '''Returns a list of video filters that are available.
     @param p_instance: libvlc instance.
-    @return: a list of module descriptions. It should be freed with L{libvlc_module_description_list_release}(). In case of an error, NULL is returned. See L{ModuleDescription} See L{libvlc_module_description_list_release}.
+    @return: a list of module descriptions. It should be freed with L{libvlc_module_description_list_release}(). In case of an error, None is returned. See L{ModuleDescription} See L{libvlc_module_description_list_release}.
     '''
     f = _Cfunctions.get('libvlc_video_filter_list_get', None) or \
         _Cfunction('libvlc_video_filter_list_get', ((1,),), None,
@@ -3477,7 +4095,7 @@ def libvlc_media_new_location(p_instance, psz_mrl):
     See L{libvlc_media_release}.
     @param p_instance: the instance.
     @param psz_mrl: the media location.
-    @return: the newly created media or NULL on error.
+    @return: the newly created media or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_new_location', None) or \
         _Cfunction('libvlc_media_new_location', ((1,), (1,),), class_result(Media),
@@ -3489,7 +4107,7 @@ def libvlc_media_new_path(p_instance, path):
     See L{libvlc_media_release}.
     @param p_instance: the instance.
     @param path: local filesystem path.
-    @return: the newly created media or NULL on error.
+    @return: the newly created media or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_new_path', None) or \
         _Cfunction('libvlc_media_new_path', ((1,), (1,),), class_result(Media),
@@ -3512,7 +4130,7 @@ def libvlc_media_new_fd(p_instance, fd):
     See L{libvlc_media_release}.
     @param p_instance: the instance.
     @param fd: open file descriptor.
-    @return: the newly created media or NULL on error.
+    @return: the newly created media or None on error.
     @version: LibVLC 1.1.5 and later.
     '''
     f = _Cfunctions.get('libvlc_media_new_fd', None) or \
@@ -3520,12 +4138,28 @@ def libvlc_media_new_fd(p_instance, fd):
                     ctypes.c_void_p, Instance, ctypes.c_int)
     return f(p_instance, fd)
 
+def libvlc_media_new_callbacks(instance, open_cb, read_cb, seek_cb, close_cb, opaque):
+    '''Create a media with custom callbacks to read the data from.
+    @param instance: LibVLC instance.
+    @param open_cb: callback to open the custom bitstream input media.
+    @param read_cb: callback to read data (must not be None).
+    @param seek_cb: callback to seek, or None if seeking is not supported.
+    @param close_cb: callback to close the media, or None if unnecessary.
+    @param opaque: data pointer for the open callback.
+    @return: the newly created media or None on error @note If open_cb is None, the opaque pointer will be passed to read_cb, seek_cb and close_cb, and the stream size will be treated as unknown. @note The callbacks may be called asynchronously (from another thread). A single stream instance need not be reentrant. However the open_cb needs to be reentrant if the media is used by multiple player instances. @warning The callbacks may be used until all or any player instances that were supplied the media item are stopped. See L{libvlc_media_release}.
+    @version: LibVLC 3.0.0 and later.
+    '''
+    f = _Cfunctions.get('libvlc_media_new_callbacks', None) or \
+        _Cfunction('libvlc_media_new_callbacks', ((1,), (1,), (1,), (1,), (1,), (1,),), class_result(Media),
+                    ctypes.c_void_p, Instance, MediaOpenCb, MediaReadCb, MediaSeekCb, MediaCloseCb, ctypes.c_void_p)
+    return f(instance, open_cb, read_cb, seek_cb, close_cb, opaque)
+
 def libvlc_media_new_as_node(p_instance, psz_name):
     '''Create a media as an empty node with a given name.
     See L{libvlc_media_release}.
     @param p_instance: the instance.
     @param psz_name: the name of the node.
-    @return: the new empty media or NULL on error.
+    @return: the new empty media or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_new_as_node', None) or \
         _Cfunction('libvlc_media_new_as_node', ((1,), (1,),), class_result(Media),
@@ -3616,7 +4250,7 @@ def libvlc_media_duplicate(p_md):
 
 def libvlc_media_get_meta(p_md, e_meta):
     '''Read the meta of the media.
-    If the media has not yet been parsed this will return NULL.
+    If the media has not yet been parsed this will return None.
     This methods automatically calls L{libvlc_media_parse_async}(), so after calling
     it you may receive a libvlc_MediaMetaChanged event. If you prefer a synchronous
     version ensure that you call L{libvlc_media_parse}() before get_meta().
@@ -3685,7 +4319,7 @@ def libvlc_media_subitems(p_md):
     the reference count of supplied media descriptor object. Use
     L{libvlc_media_list_release}() to decrement the reference counting.
     @param p_md: media descriptor object.
-    @return: list of media descriptor subitems or NULL.
+    @return: list of media descriptor subitems or None.
     '''
     f = _Cfunctions.get('libvlc_media_subitems', None) or \
         _Cfunction('libvlc_media_subitems', ((1,),), class_result(MediaList),
@@ -3715,7 +4349,7 @@ def libvlc_media_get_duration(p_md):
 
 def libvlc_media_parse(p_md):
     '''Parse a media.
-    This fetches (local) meta data and tracks information.
+    This fetches (local) art, meta data and tracks information.
     The method is synchronous.
     See L{libvlc_media_parse_async}
     See L{libvlc_media_get_meta}
@@ -3729,7 +4363,7 @@ def libvlc_media_parse(p_md):
 
 def libvlc_media_parse_async(p_md):
     '''Parse a media.
-    This fetches (local) meta data and tracks information.
+    This fetches (local) art, meta data and tracks information.
     The method is the asynchronous of L{libvlc_media_parse}().
     To track when this is over you can listen to libvlc_MediaParsedChanged
     event. However if the media was already parsed you will not receive this
@@ -3744,6 +4378,30 @@ def libvlc_media_parse_async(p_md):
         _Cfunction('libvlc_media_parse_async', ((1,),), None,
                     None, Media)
     return f(p_md)
+
+def libvlc_media_parse_with_options(p_md, parse_flag):
+    '''Parse the media asynchronously with options.
+    This fetches (local or network) art, meta data and/or tracks information.
+    This method is the extended version of L{libvlc_media_parse_async}().
+    To track when this is over you can listen to libvlc_MediaParsedChanged
+    event. However if this functions returns an error, you will not receive this
+    event.
+    It uses a flag to specify parse options (see libvlc_media_parse_flag_t). All
+    these flags can be combined. By default, media is parsed if it's a local
+    file.
+    See libvlc_MediaParsedChanged
+    See L{libvlc_media_get_meta}
+    See L{libvlc_media_tracks_get}
+    See libvlc_media_parse_flag_t.
+    @param p_md: media descriptor object.
+    @param parse_flag: parse options:
+    @return: -1 in case of error, 0 otherwise.
+    @version: LibVLC 3.0.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_media_parse_with_options', None) or \
+        _Cfunction('libvlc_media_parse_with_options', ((1,), (1,),), None,
+                    ctypes.c_int, Media, MediaParseFlag)
+    return f(p_md, parse_flag)
 
 def libvlc_media_is_parsed(p_md):
     '''Get Parsed status for media descriptor object.
@@ -3794,6 +4452,18 @@ def libvlc_media_tracks_get(p_md, tracks):
                     ctypes.c_uint, Media, ctypes.POINTER(ctypes.POINTER(MediaTrack)))
     return f(p_md, tracks)
 
+def libvlc_media_get_codec_description(i_type, i_codec):
+    '''Get codec description from media elementary stream.
+    @param i_type: i_type from L{MediaTrack}.
+    @param i_codec: i_codec or i_original_fourcc from L{MediaTrack}.
+    @return: codec description.
+    @version: LibVLC 3.0.0 and later. See L{MediaTrack}.
+    '''
+    f = _Cfunctions.get('libvlc_media_get_codec_description', None) or \
+        _Cfunction('libvlc_media_get_codec_description', ((1,), (1,),), None,
+                    ctypes.c_char_p, TrackType, ctypes.c_uint32)
+    return f(i_type, i_codec)
+
 def libvlc_media_tracks_release(p_tracks, i_count):
     '''Release media descriptor's elementary streams description array.
     @param p_tracks: tracks info array to release.
@@ -3805,16 +4475,62 @@ def libvlc_media_tracks_release(p_tracks, i_count):
                     None, ctypes.POINTER(MediaTrack), ctypes.c_uint)
     return f(p_tracks, i_count)
 
-def libvlc_media_discoverer_new_from_name(p_inst, psz_name):
-    '''Discover media service by name.
+def libvlc_media_get_type(p_md):
+    '''Get the media type of the media descriptor object.
+    @param p_md: media descriptor object.
+    @return: media type.
+    @version: LibVLC 3.0.0 and later. See libvlc_media_type_t.
+    '''
+    f = _Cfunctions.get('libvlc_media_get_type', None) or \
+        _Cfunction('libvlc_media_get_type', ((1,),), None,
+                    MediaType, Media)
+    return f(p_md)
+
+def libvlc_media_discoverer_new(p_inst, psz_name):
+    '''Create a media discoverer object by name.
+    After this object is created, you should attach to events in order to be
+    notified of the discoverer state.
+    You should also attach to media_list events in order to be notified of new
+    items discovered.
+    You need to call L{libvlc_media_discoverer_start}() in order to start the
+    discovery.
+    See L{libvlc_media_discoverer_media_list}
+    See L{libvlc_media_discoverer_event_manager}
+    See L{libvlc_media_discoverer_start}.
     @param p_inst: libvlc instance.
     @param psz_name: service name.
-    @return: media discover object or NULL in case of error.
+    @return: media discover object or None in case of error.
+    @version: LibVLC 3.0.0 or later.
     '''
-    f = _Cfunctions.get('libvlc_media_discoverer_new_from_name', None) or \
-        _Cfunction('libvlc_media_discoverer_new_from_name', ((1,), (1,),), class_result(MediaDiscoverer),
+    f = _Cfunctions.get('libvlc_media_discoverer_new', None) or \
+        _Cfunction('libvlc_media_discoverer_new', ((1,), (1,),), class_result(MediaDiscoverer),
                     ctypes.c_void_p, Instance, ctypes.c_char_p)
     return f(p_inst, psz_name)
+
+def libvlc_media_discoverer_start(p_mdis):
+    '''Start media discovery.
+    To stop it, call L{libvlc_media_discoverer_stop}() or
+    L{libvlc_media_discoverer_release}() directly.
+    See L{libvlc_media_discoverer_stop}.
+    @param p_mdis: media discover object.
+    @return: -1 in case of error, 0 otherwise.
+    @version: LibVLC 3.0.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_media_discoverer_start', None) or \
+        _Cfunction('libvlc_media_discoverer_start', ((1,),), None,
+                    ctypes.c_int, MediaDiscoverer)
+    return f(p_mdis)
+
+def libvlc_media_discoverer_stop(p_mdis):
+    '''Stop media discovery.
+    See L{libvlc_media_discoverer_start}.
+    @param p_mdis: media discover object.
+    @version: LibVLC 3.0.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_media_discoverer_stop', None) or \
+        _Cfunction('libvlc_media_discoverer_stop', ((1,),), None,
+                    None, MediaDiscoverer)
+    return f(p_mdis)
 
 def libvlc_media_discoverer_release(p_mdis):
     '''Release media discover object. If the reference count reaches 0, then
@@ -3869,7 +4585,7 @@ def libvlc_media_discoverer_is_running(p_mdis):
 def libvlc_media_library_new(p_instance):
     '''Create an new Media Library object.
     @param p_instance: the libvlc instance.
-    @return: a new object or NULL on error.
+    @return: a new object or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_library_new', None) or \
         _Cfunction('libvlc_media_library_new', ((1,),), class_result(MediaLibrary),
@@ -3921,7 +4637,7 @@ def libvlc_media_library_media_list(p_mlib):
 def libvlc_media_list_new(p_instance):
     '''Create an empty media list.
     @param p_instance: libvlc instance.
-    @return: empty media list, or NULL on error.
+    @return: empty media list, or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_list_new', None) or \
         _Cfunction('libvlc_media_list_new', ((1,),), class_result(MediaList),
@@ -4023,7 +4739,7 @@ def libvlc_media_list_item_at_index(p_ml, i_pos):
     The L{libvlc_media_list_lock} should be held upon entering this function.
     @param p_ml: a media list instance.
     @param i_pos: position in array where to insert.
-    @return: media instance at position i_pos, or NULL if not found. In case of success, L{libvlc_media_retain}() is called to increase the refcount on the media.
+    @return: media instance at position i_pos, or None if not found. In case of success, L{libvlc_media_retain}() is called to increase the refcount on the media.
     '''
     f = _Cfunctions.get('libvlc_media_list_item_at_index', None) or \
         _Cfunction('libvlc_media_list_item_at_index', ((1,), (1,),), class_result(Media),
@@ -4086,7 +4802,7 @@ def libvlc_media_list_event_manager(p_ml):
 def libvlc_media_list_player_new(p_instance):
     '''Create new media_list_player.
     @param p_instance: libvlc instance.
-    @return: media list player instance or NULL on error.
+    @return: media list player instance or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_list_player_new', None) or \
         _Cfunction('libvlc_media_list_player_new', ((1,),), class_result(MediaListPlayer),
@@ -4248,7 +4964,7 @@ def libvlc_media_list_player_set_playback_mode(p_mlp, e_mode):
 def libvlc_media_player_new(p_libvlc_instance):
     '''Create an empty Media Player object.
     @param p_libvlc_instance: the libvlc instance in which the Media Player should be created.
-    @return: a new media player object, or NULL on error.
+    @return: a new media player object, or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_player_new', None) or \
         _Cfunction('libvlc_media_player_new', ((1,),), class_result(MediaPlayer),
@@ -4258,7 +4974,7 @@ def libvlc_media_player_new(p_libvlc_instance):
 def libvlc_media_player_new_from_media(p_md):
     '''Create a Media Player object from a Media.
     @param p_md: the media. Afterwards the p_md can be safely destroyed.
-    @return: a new media player object, or NULL on error.
+    @return: a new media player object, or None on error.
     '''
     f = _Cfunctions.get('libvlc_media_player_new_from_media', None) or \
         _Cfunction('libvlc_media_player_new_from_media', ((1,),), class_result(MediaPlayer),
@@ -4302,7 +5018,7 @@ def libvlc_media_player_set_media(p_mi, p_md):
 def libvlc_media_player_get_media(p_mi):
     '''Get the media used by the media_player.
     @param p_mi: the Media Player.
-    @return: the media associated with p_mi, or NULL if no media is associated.
+    @return: the media associated with p_mi, or None if no media is associated.
     '''
     f = _Cfunctions.get('libvlc_media_player_get_media', None) or \
         _Cfunction('libvlc_media_player_get_media', ((1,),), class_result(Media),
@@ -4374,9 +5090,9 @@ def libvlc_video_set_callbacks(mp, lock, unlock, display, opaque):
     Use L{libvlc_video_set_format}() or L{libvlc_video_set_format_callbacks}()
     to configure the decoded format.
     @param mp: the media player.
-    @param lock: callback to lock video memory (must not be NULL).
-    @param unlock: callback to unlock video memory (or NULL if not needed).
-    @param display: callback to display video (or NULL if not needed).
+    @param lock: callback to lock video memory (must not be None).
+    @param unlock: callback to unlock video memory (or None if not needed).
+    @param display: callback to display video (or None if not needed).
     @param opaque: private pointer for the three callbacks (as first parameter).
     @version: LibVLC 1.1.1 or later.
     '''
@@ -4406,8 +5122,8 @@ def libvlc_video_set_format_callbacks(mp, setup, cleanup):
     '''Set decoded video chroma and dimensions. This only works in combination with
     L{libvlc_video_set_callbacks}().
     @param mp: the media player.
-    @param setup: callback to select the video format (cannot be NULL).
-    @param cleanup: callback to release any allocated resources (or NULL).
+    @param setup: callback to select the video format (cannot be None).
+    @param cleanup: callback to release any allocated resources (or None).
     @version: LibVLC 2.0.0 or later.
     '''
     f = _Cfunctions.get('libvlc_video_set_format_callbacks', None) or \
@@ -4420,7 +5136,7 @@ def libvlc_media_player_set_nsobject(p_mi, drawable):
     Use the vout called "macosx".
     The drawable is an NSObject that follow the VLCOpenGLVideoViewEmbedding
     protocol:
-    @begincode
+    @code.m
     \@protocol VLCOpenGLVideoViewEmbedding <NSObject>
     - (void)addVoutSubview:(NSView *)view;
     - (void)removeVoutSubview:(NSView *)view;
@@ -4429,7 +5145,7 @@ def libvlc_media_player_set_nsobject(p_mi, drawable):
     Or it can be an NSView object.
     If you want to use it along with Qt4 see the QMacCocoaViewContainer. Then
     the following code should work:
-    @begincode
+    @code.mm
     
         NSView *video = [[NSView alloc] init];
         QMacCocoaViewContainer *container = new QMacCocoaViewContainer(video, parent);
@@ -4523,7 +5239,7 @@ def libvlc_media_player_get_hwnd(p_mi):
     L{libvlc_media_player_set_hwnd}(). The handle will be returned even if LibVLC
     is not currently outputting any video to it.
     @param p_mi: the Media Player.
-    @return: a window handle or NULL if there are none.
+    @return: a window handle or None if there are none.
     '''
     f = _Cfunctions.get('libvlc_media_player_get_hwnd', None) or \
         _Cfunction('libvlc_media_player_get_hwnd', ((1,),), None,
@@ -4535,11 +5251,11 @@ def libvlc_audio_set_callbacks(mp, play, pause, resume, flush, drain, opaque):
     Use L{libvlc_audio_set_format}() or L{libvlc_audio_set_format_callbacks}()
     to configure the decoded audio format.
     @param mp: the media player.
-    @param play: callback to play audio samples (must not be NULL).
-    @param pause: callback to pause playback (or NULL to ignore).
-    @param resume: callback to resume playback (or NULL to ignore).
-    @param flush: callback to flush audio buffers (or NULL to ignore).
-    @param drain: callback to drain audio buffers (or NULL to ignore).
+    @param play: callback to play audio samples (must not be None).
+    @param pause: callback to pause playback (or None to ignore).
+    @param resume: callback to resume playback (or None to ignore).
+    @param flush: callback to flush audio buffers (or None to ignore).
+    @param drain: callback to drain audio buffers (or None to ignore).
     @param opaque: private pointer for the audio callbacks (as first parameter).
     @version: LibVLC 2.0.0 or later.
     '''
@@ -4549,11 +5265,12 @@ def libvlc_audio_set_callbacks(mp, play, pause, resume, flush, drain, opaque):
     return f(mp, play, pause, resume, flush, drain, opaque)
 
 def libvlc_audio_set_volume_callback(mp, set_volume):
-    '''Set callbacks and private data for decoded audio.
+    '''Set callbacks and private data for decoded audio. This only works in
+    combination with L{libvlc_audio_set_callbacks}().
     Use L{libvlc_audio_set_format}() or L{libvlc_audio_set_format_callbacks}()
     to configure the decoded audio format.
     @param mp: the media player.
-    @param set_volume: callback to apply audio volume, or NULL to apply volume in software.
+    @param set_volume: callback to apply audio volume, or None to apply volume in software.
     @version: LibVLC 2.0.0 or later.
     '''
     f = _Cfunctions.get('libvlc_audio_set_volume_callback', None) or \
@@ -4565,8 +5282,8 @@ def libvlc_audio_set_format_callbacks(mp, setup, cleanup):
     '''Set decoded audio format. This only works in combination with
     L{libvlc_audio_set_callbacks}().
     @param mp: the media player.
-    @param setup: callback to select the audio format (cannot be NULL).
-    @param cleanup: callback to release any allocated resources (or NULL).
+    @param setup: callback to select the audio format (cannot be None).
+    @param cleanup: callback to release any allocated resources (or None).
     @version: LibVLC 2.0.0 or later.
     '''
     f = _Cfunctions.get('libvlc_audio_set_format_callbacks', None) or \
@@ -4814,6 +5531,17 @@ def libvlc_media_player_can_pause(p_mi):
                     ctypes.c_int, MediaPlayer)
     return f(p_mi)
 
+def libvlc_media_player_program_scrambled(p_mi):
+    '''Check if the current program is scrambled.
+    @param p_mi: the media player.
+    @return: true if the current program is scrambled \libvlc_return_bool.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_media_player_program_scrambled', None) or \
+        _Cfunction('libvlc_media_player_program_scrambled', ((1,),), None,
+                    ctypes.c_int, MediaPlayer)
+    return f(p_mi)
+
 def libvlc_media_player_next_frame(p_mi):
     '''Display the next frame (if supported).
     @param p_mi: the media player.
@@ -4833,6 +5561,18 @@ def libvlc_media_player_navigate(p_mi, navigate):
         _Cfunction('libvlc_media_player_navigate', ((1,), (1,),), None,
                     None, MediaPlayer, ctypes.c_uint)
     return f(p_mi, navigate)
+
+def libvlc_media_player_set_video_title_display(p_mi, position, timeout):
+    '''Set if, and how, the video title will be shown when media is played.
+    @param p_mi: the media player.
+    @param position: position at which to display the title, or libvlc_position_disable to prevent the title from being displayed.
+    @param timeout: title display timeout in milliseconds (ignored if libvlc_position_disable).
+    @version: libVLC 2.1.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_media_player_set_video_title_display', None) or \
+        _Cfunction('libvlc_media_player_set_video_title_display', ((1,), (1,), (1,),), None,
+                    None, MediaPlayer, Position, ctypes.c_int)
+    return f(p_mi, position, timeout)
 
 def libvlc_track_description_list_release(p_track_description):
     '''Release (free) L{TrackDescription}.
@@ -4971,7 +5711,7 @@ def libvlc_video_set_scale(p_mi, f_factor):
 def libvlc_video_get_aspect_ratio(p_mi):
     '''Get current video aspect ratio.
     @param p_mi: the media player.
-    @return: the video aspect ratio or NULL if unspecified (the result must be released with free() or L{libvlc_free}()).
+    @return: the video aspect ratio or None if unspecified (the result must be released with free() or L{libvlc_free}()).
     '''
     f = _Cfunctions.get('libvlc_video_get_aspect_ratio', None) or \
         _Cfunction('libvlc_video_get_aspect_ratio', ((1,),), string_result,
@@ -4981,7 +5721,7 @@ def libvlc_video_get_aspect_ratio(p_mi):
 def libvlc_video_set_aspect_ratio(p_mi, psz_aspect):
     '''Set new video aspect ratio.
     @param p_mi: the media player.
-    @param psz_aspect: new video aspect-ratio or NULL to reset to default @note Invalid aspect ratios are ignored.
+    @param psz_aspect: new video aspect-ratio or None to reset to default @note Invalid aspect ratios are ignored.
     '''
     f = _Cfunctions.get('libvlc_video_set_aspect_ratio', None) or \
         _Cfunction('libvlc_video_set_aspect_ratio', ((1,), (1,),), None,
@@ -5011,7 +5751,7 @@ def libvlc_video_get_spu_count(p_mi):
 def libvlc_video_get_spu_description(p_mi):
     '''Get the description of available video subtitles.
     @param p_mi: the media player.
-    @return: list containing description of available video subtitles.
+    @return: list containing description of available video subtitles. It must be freed with L{libvlc_track_description_list_release}().
     '''
     f = _Cfunctions.get('libvlc_video_get_spu_description', None) or \
         _Cfunction('libvlc_video_get_spu_description', ((1,),), None,
@@ -5067,31 +5807,57 @@ def libvlc_video_set_spu_delay(p_mi, i_delay):
                     ctypes.c_int, MediaPlayer, ctypes.c_int64)
     return f(p_mi, i_delay)
 
-def libvlc_video_get_title_description(p_mi):
-    '''Get the description of available titles.
+def libvlc_media_player_get_full_title_descriptions(p_mi, titles):
+    '''Get the full description of available titles.
     @param p_mi: the media player.
-    @return: list containing description of available titles.
+    @param address: to store an allocated array of title descriptions descriptions (must be freed with L{libvlc_title_descriptions_release}() by the caller) [OUT].
+    @return: the number of titles (-1 on error).
+    @version: LibVLC 3.0.0 and later.
     '''
-    f = _Cfunctions.get('libvlc_video_get_title_description', None) or \
-        _Cfunction('libvlc_video_get_title_description', ((1,),), None,
-                    ctypes.POINTER(TrackDescription), MediaPlayer)
-    return f(p_mi)
+    f = _Cfunctions.get('libvlc_media_player_get_full_title_descriptions', None) or \
+        _Cfunction('libvlc_media_player_get_full_title_descriptions', ((1,), (1,),), None,
+                    ctypes.c_int, MediaPlayer, ctypes.POINTER(ctypes.POINTER(TitleDescription)))
+    return f(p_mi, titles)
 
-def libvlc_video_get_chapter_description(p_mi, i_title):
-    '''Get the description of available chapters for specific title.
-    @param p_mi: the media player.
-    @param i_title: selected title.
-    @return: list containing description of available chapter for title i_title.
+def libvlc_title_descriptions_release(p_titles, i_count):
+    '''Release a title description.
+    @param title: description array to release.
+    @param number: of title descriptions to release.
+    @version: LibVLC 3.0.0 and later.
     '''
-    f = _Cfunctions.get('libvlc_video_get_chapter_description', None) or \
-        _Cfunction('libvlc_video_get_chapter_description', ((1,), (1,),), None,
-                    ctypes.POINTER(TrackDescription), MediaPlayer, ctypes.c_int)
-    return f(p_mi, i_title)
+    f = _Cfunctions.get('libvlc_title_descriptions_release', None) or \
+        _Cfunction('libvlc_title_descriptions_release', ((1,), (1,),), None,
+                    None, ctypes.POINTER(TitleDescription), ctypes.c_uint)
+    return f(p_titles, i_count)
+
+def libvlc_media_player_get_full_chapter_descriptions(p_mi, i_chapters_of_title, pp_chapters):
+    '''Get the full description of available chapters.
+    @param p_mi: the media player.
+    @param index: of the title to query for chapters.
+    @param address: to store an allocated array of chapter descriptions descriptions (must be freed with L{libvlc_chapter_descriptions_release}() by the caller) [OUT].
+    @return: the number of chapters (-1 on error).
+    @version: LibVLC 3.0.0 and later.
+    '''
+    f = _Cfunctions.get('libvlc_media_player_get_full_chapter_descriptions', None) or \
+        _Cfunction('libvlc_media_player_get_full_chapter_descriptions', ((1,), (1,), (1,),), None,
+                    ctypes.c_int, MediaPlayer, ctypes.c_int, ctypes.POINTER(ctypes.POINTER(ChapterDescription)))
+    return f(p_mi, i_chapters_of_title, pp_chapters)
+
+def libvlc_chapter_descriptions_release(p_chapters, i_count):
+    '''Release a chapter description.
+    @param chapter: description array to release.
+    @param number: of chapter descriptions to release.
+    @version: LibVLC 3.0.0 and later.
+    '''
+    f = _Cfunctions.get('libvlc_chapter_descriptions_release', None) or \
+        _Cfunction('libvlc_chapter_descriptions_release', ((1,), (1,),), None,
+                    None, ctypes.POINTER(ChapterDescription), ctypes.c_uint)
+    return f(p_chapters, i_count)
 
 def libvlc_video_get_crop_geometry(p_mi):
     '''Get current crop filter geometry.
     @param p_mi: the media player.
-    @return: the crop filter geometry or NULL if unset.
+    @return: the crop filter geometry or None if unset.
     '''
     f = _Cfunctions.get('libvlc_video_get_crop_geometry', None) or \
         _Cfunction('libvlc_video_get_crop_geometry', ((1,),), string_result,
@@ -5101,7 +5867,7 @@ def libvlc_video_get_crop_geometry(p_mi):
 def libvlc_video_set_crop_geometry(p_mi, psz_geometry):
     '''Set new crop filter geometry.
     @param p_mi: the media player.
-    @param psz_geometry: new crop filter geometry (NULL to unset).
+    @param psz_geometry: new crop filter geometry (None to unset).
     '''
     f = _Cfunctions.get('libvlc_video_set_crop_geometry', None) or \
         _Cfunction('libvlc_video_set_crop_geometry', ((1,), (1,),), None,
@@ -5150,7 +5916,7 @@ def libvlc_video_get_track_count(p_mi):
 def libvlc_video_get_track_description(p_mi):
     '''Get the description of available video tracks.
     @param p_mi: media player.
-    @return: list with description of available video tracks, or NULL on error.
+    @return: list with description of available video tracks, or None on error. It must be freed with L{libvlc_track_description_list_release}().
     '''
     f = _Cfunctions.get('libvlc_video_get_track_description', None) or \
         _Cfunction('libvlc_video_get_track_description', ((1,),), None,
@@ -5197,7 +5963,7 @@ def libvlc_video_take_snapshot(p_mi, num, psz_filepath, i_width, i_height):
 def libvlc_video_set_deinterlace(p_mi, psz_mode):
     '''Enable or disable deinterlace filter.
     @param p_mi: libvlc media player.
-    @param psz_mode: type of deinterlace filter, NULL to disable.
+    @param psz_mode: type of deinterlace filter, None to disable.
     '''
     f = _Cfunctions.get('libvlc_video_set_deinterlace', None) or \
         _Cfunction('libvlc_video_set_deinterlace', ((1,), (1,),), None,
@@ -5335,9 +6101,9 @@ def libvlc_video_set_adjust_float(p_mi, option, value):
     return f(p_mi, option, value)
 
 def libvlc_audio_output_list_get(p_instance):
-    '''Gets the list of available audio outputs.
+    '''Gets the list of available audio output modules.
     @param p_instance: libvlc instance.
-    @return: list of available audio outputs. It must be freed it with In case of error, NULL is returned.
+    @return: list of available audio outputs. It must be freed with In case of error, None is returned.
     '''
     f = _Cfunctions.get('libvlc_audio_output_list_get', None) or \
         _Cfunction('libvlc_audio_output_list_get', ((1,),), None,
@@ -5345,7 +6111,7 @@ def libvlc_audio_output_list_get(p_instance):
     return f(p_instance)
 
 def libvlc_audio_output_list_release(p_list):
-    '''Frees the list of available audio outputs.
+    '''Frees the list of available audio output modules.
     @param p_list: list with audio outputs for release.
     '''
     f = _Cfunctions.get('libvlc_audio_output_list_release', None) or \
@@ -5354,7 +6120,7 @@ def libvlc_audio_output_list_release(p_list):
     return f(p_list)
 
 def libvlc_audio_output_set(p_mi, psz_name):
-    '''Sets the audio output.
+    '''Selects an audio output module.
     @note: Any change will take be effect only after playback is stopped and
     restarted. Audio output cannot be changed while playing.
     @param p_mi: media player.
@@ -5366,10 +6132,28 @@ def libvlc_audio_output_set(p_mi, psz_name):
                     ctypes.c_int, MediaPlayer, ctypes.c_char_p)
     return f(p_mi, psz_name)
 
-def libvlc_audio_output_device_list_get(p_instance, aout):
-    '''Gets a list of audio output devices for a given audio output.
+def libvlc_audio_output_device_enum(mp):
+    '''Gets a list of potential audio output devices,
     See L{libvlc_audio_output_device_set}().
-    @note: Not all audio outputs support this. In particular, an empty (NULL)
+    @note: Not all audio outputs support enumerating devices.
+    The audio output may be functional even if the list is empty (None).
+    @note: The list may not be exhaustive.
+    @warning: Some audio output devices in the list might not actually work in
+    some circumstances. By default, it is recommended to not specify any
+    explicit audio device.
+    @param mp: media player.
+    @return: A None-terminated linked list of potential audio output devices. It must be freed with L{libvlc_audio_output_device_list_release}().
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_output_device_enum', None) or \
+        _Cfunction('libvlc_audio_output_device_enum', ((1,),), None,
+                    ctypes.POINTER(AudioOutputDevice), MediaPlayer)
+    return f(mp)
+
+def libvlc_audio_output_device_list_get(p_instance, aout):
+    '''Gets a list of audio output devices for a given audio output module,
+    See L{libvlc_audio_output_device_set}().
+    @note: Not all audio outputs support this. In particular, an empty (None)
     list of devices does B{not} imply that the specified audio output does
     not work.
     @note: The list might not be exhaustive.
@@ -5378,7 +6162,7 @@ def libvlc_audio_output_device_list_get(p_instance, aout):
     explicit audio device.
     @param p_instance: libvlc instance.
     @param psz_aout: audio output name (as returned by L{libvlc_audio_output_list_get}()).
-    @return: A NULL-terminated linked list of potential audio output devices. It must be freed it with L{libvlc_audio_output_device_list_release}().
+    @return: A None-terminated linked list of potential audio output devices. It must be freed with L{libvlc_audio_output_device_list_release}().
     @version: LibVLC 2.1.0 or later.
     '''
     f = _Cfunctions.get('libvlc_audio_output_device_list_get', None) or \
@@ -5396,25 +6180,57 @@ def libvlc_audio_output_device_list_release(p_list):
                     None, ctypes.POINTER(AudioOutputDevice))
     return f(p_list)
 
-def libvlc_audio_output_device_set(p_mi, psz_audio_output, psz_device_id):
-    '''Configures an explicit audio output device for a given audio output plugin.
-    A list of possible devices can be obtained with
+def libvlc_audio_output_device_set(mp, module, device_id):
+    '''Configures an explicit audio output device.
+    If the module paramater is None, audio output will be moved to the device
+    specified by the device identifier string immediately. This is the
+    recommended usage.
+    A list of adequate potential device strings can be obtained with
+    L{libvlc_audio_output_device_enum}().
+    However passing None is supported in LibVLC version 2.2.0 and later only;
+    in earlier versions, this function would have no effects when the module
+    parameter was None.
+    If the module parameter is not None, the device parameter of the
+    corresponding audio output, if it exists, will be set to the specified
+    string. Note that some audio output modules do not have such a parameter
+    (notably MMDevice and PulseAudio).
+    A list of adequate potential device strings can be obtained with
     L{libvlc_audio_output_device_list_get}().
     @note: This function does not select the specified audio output plugin.
     L{libvlc_audio_output_set}() is used for that purpose.
     @warning: The syntax for the device parameter depends on the audio output.
-    This is not portable. Only use this function if you know what you are doing.
-    Some audio outputs do not support this function (e.g. PulseAudio, WASAPI).
-    Some audio outputs require further parameters (e.g. ALSA: channels map).
-    @param p_mi: media player.
-    @param psz_audio_output: - name of audio output, See L{AudioOutput}.
-    @param psz_device_id: device.
-    @return: Nothing. Errors are ignored.
+    Some audio output modules require further parameters (e.g. a channels map
+    in the case of ALSA).
+    @param mp: media player.
+    @param module: If None, current audio output module. if non-None, name of audio output module.
+    @param device_id: device identifier string.
+    @return: Nothing. Errors are ignored (this is a design bug).
     '''
     f = _Cfunctions.get('libvlc_audio_output_device_set', None) or \
         _Cfunction('libvlc_audio_output_device_set', ((1,), (1,), (1,),), None,
                     None, MediaPlayer, ctypes.c_char_p, ctypes.c_char_p)
-    return f(p_mi, psz_audio_output, psz_device_id)
+    return f(mp, module, device_id)
+
+def libvlc_audio_output_device_get(mp):
+    '''Get the current audio output device identifier.
+    This complements L{libvlc_audio_output_device_set}().
+    @warning: The initial value for the current audio output device identifier
+    may not be set or may be some unknown value. A LibVLC application should
+    compare this value against the known device identifiers (e.g. those that
+    were previously retrieved by a call to L{libvlc_audio_output_device_enum} or
+    L{libvlc_audio_output_device_list_get}) to find the current audio output device.
+    It is possible that the selected audio output device changes (an external
+    change) without a call to L{libvlc_audio_output_device_set}. That may make this
+    method unsuitable to use if a LibVLC application is attempting to track
+    dynamic audio device changes as they happen.
+    @param mp: media player.
+    @return: the current audio output device identifier None if no device is selected or in case of error (the result must be released with free() or L{libvlc_free}()).
+    @version: LibVLC 3.0.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_output_device_get', None) or \
+        _Cfunction('libvlc_audio_output_device_get', ((1,),), None,
+                    ctypes.c_char_p, MediaPlayer)
+    return f(mp)
 
 def libvlc_audio_toggle_mute(p_mi):
     '''Toggle mute status.
@@ -5479,7 +6295,7 @@ def libvlc_audio_get_track_count(p_mi):
 def libvlc_audio_get_track_description(p_mi):
     '''Get the description of available audio tracks.
     @param p_mi: media player.
-    @return: list with description of available audio tracks, or NULL.
+    @return: list with description of available audio tracks, or None. It must be freed with L{libvlc_track_description_list_release}().
     '''
     f = _Cfunctions.get('libvlc_audio_get_track_description', None) or \
         _Cfunction('libvlc_audio_get_track_description', ((1,),), None,
@@ -5550,6 +6366,175 @@ def libvlc_audio_set_delay(p_mi, i_delay):
         _Cfunction('libvlc_audio_set_delay', ((1,), (1,),), None,
                     ctypes.c_int, MediaPlayer, ctypes.c_int64)
     return f(p_mi, i_delay)
+
+def libvlc_audio_equalizer_get_preset_count():
+    '''Get the number of equalizer presets.
+    @return: number of presets.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_get_preset_count', None) or \
+        _Cfunction('libvlc_audio_equalizer_get_preset_count', (), None,
+                    ctypes.c_uint)
+    return f()
+
+def libvlc_audio_equalizer_get_preset_name(u_index):
+    '''Get the name of a particular equalizer preset.
+    This name can be used, for example, to prepare a preset label or menu in a user
+    interface.
+    @param u_index: index of the preset, counting from zero.
+    @return: preset name, or None if there is no such preset.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_get_preset_name', None) or \
+        _Cfunction('libvlc_audio_equalizer_get_preset_name', ((1,),), None,
+                    ctypes.c_char_p, ctypes.c_uint)
+    return f(u_index)
+
+def libvlc_audio_equalizer_get_band_count():
+    '''Get the number of distinct frequency bands for an equalizer.
+    @return: number of frequency bands.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_get_band_count', None) or \
+        _Cfunction('libvlc_audio_equalizer_get_band_count', (), None,
+                    ctypes.c_uint)
+    return f()
+
+def libvlc_audio_equalizer_get_band_frequency(u_index):
+    '''Get a particular equalizer band frequency.
+    This value can be used, for example, to create a label for an equalizer band control
+    in a user interface.
+    @param u_index: index of the band, counting from zero.
+    @return: equalizer band frequency (Hz), or -1 if there is no such band.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_get_band_frequency', None) or \
+        _Cfunction('libvlc_audio_equalizer_get_band_frequency', ((1,),), None,
+                    ctypes.c_float, ctypes.c_uint)
+    return f(u_index)
+
+def libvlc_audio_equalizer_new():
+    '''Create a new default equalizer, with all frequency values zeroed.
+    The new equalizer can subsequently be applied to a media player by invoking
+    L{libvlc_media_player_set_equalizer}().
+    The returned handle should be freed via L{libvlc_audio_equalizer_release}() when
+    it is no longer needed.
+    @return: opaque equalizer handle, or None on error.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_new', None) or \
+        _Cfunction('libvlc_audio_equalizer_new', (), None,
+                    ctypes.c_void_p)
+    return f()
+
+def libvlc_audio_equalizer_new_from_preset(u_index):
+    '''Create a new equalizer, with initial frequency values copied from an existing
+    preset.
+    The new equalizer can subsequently be applied to a media player by invoking
+    L{libvlc_media_player_set_equalizer}().
+    The returned handle should be freed via L{libvlc_audio_equalizer_release}() when
+    it is no longer needed.
+    @param u_index: index of the preset, counting from zero.
+    @return: opaque equalizer handle, or None on error.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_new_from_preset', None) or \
+        _Cfunction('libvlc_audio_equalizer_new_from_preset', ((1,),), None,
+                    ctypes.c_void_p, ctypes.c_uint)
+    return f(u_index)
+
+def libvlc_audio_equalizer_release(p_equalizer):
+    '''Release a previously created equalizer instance.
+    The equalizer was previously created by using L{libvlc_audio_equalizer_new}() or
+    L{libvlc_audio_equalizer_new_from_preset}().
+    It is safe to invoke this method with a None p_equalizer parameter for no effect.
+    @param p_equalizer: opaque equalizer handle, or None.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_release', None) or \
+        _Cfunction('libvlc_audio_equalizer_release', ((1,),), None,
+                    None, ctypes.c_void_p)
+    return f(p_equalizer)
+
+def libvlc_audio_equalizer_set_preamp(p_equalizer, f_preamp):
+    '''Set a new pre-amplification value for an equalizer.
+    The new equalizer settings are subsequently applied to a media player by invoking
+    L{libvlc_media_player_set_equalizer}().
+    The supplied amplification value will be clamped to the -20.0 to +20.0 range.
+    @param p_equalizer: valid equalizer handle, must not be None.
+    @param f_preamp: preamp value (-20.0 to 20.0 Hz).
+    @return: zero on success, -1 on error.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_set_preamp', None) or \
+        _Cfunction('libvlc_audio_equalizer_set_preamp', ((1,), (1,),), None,
+                    ctypes.c_int, ctypes.c_void_p, ctypes.c_float)
+    return f(p_equalizer, f_preamp)
+
+def libvlc_audio_equalizer_get_preamp(p_equalizer):
+    '''Get the current pre-amplification value from an equalizer.
+    @param p_equalizer: valid equalizer handle, must not be None.
+    @return: preamp value (Hz).
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_get_preamp', None) or \
+        _Cfunction('libvlc_audio_equalizer_get_preamp', ((1,),), None,
+                    ctypes.c_float, ctypes.c_void_p)
+    return f(p_equalizer)
+
+def libvlc_audio_equalizer_set_amp_at_index(p_equalizer, f_amp, u_band):
+    '''Set a new amplification value for a particular equalizer frequency band.
+    The new equalizer settings are subsequently applied to a media player by invoking
+    L{libvlc_media_player_set_equalizer}().
+    The supplied amplification value will be clamped to the -20.0 to +20.0 range.
+    @param p_equalizer: valid equalizer handle, must not be None.
+    @param f_amp: amplification value (-20.0 to 20.0 Hz).
+    @param u_band: index, counting from zero, of the frequency band to set.
+    @return: zero on success, -1 on error.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_set_amp_at_index', None) or \
+        _Cfunction('libvlc_audio_equalizer_set_amp_at_index', ((1,), (1,), (1,),), None,
+                    ctypes.c_int, ctypes.c_void_p, ctypes.c_float, ctypes.c_uint)
+    return f(p_equalizer, f_amp, u_band)
+
+def libvlc_audio_equalizer_get_amp_at_index(p_equalizer, u_band):
+    '''Get the amplification value for a particular equalizer frequency band.
+    @param p_equalizer: valid equalizer handle, must not be None.
+    @param u_band: index, counting from zero, of the frequency band to get.
+    @return: amplification value (Hz); NaN if there is no such frequency band.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_audio_equalizer_get_amp_at_index', None) or \
+        _Cfunction('libvlc_audio_equalizer_get_amp_at_index', ((1,), (1,),), None,
+                    ctypes.c_float, ctypes.c_void_p, ctypes.c_uint)
+    return f(p_equalizer, u_band)
+
+def libvlc_media_player_set_equalizer(p_mi, p_equalizer):
+    '''Apply new equalizer settings to a media player.
+    The equalizer is first created by invoking L{libvlc_audio_equalizer_new}() or
+    L{libvlc_audio_equalizer_new_from_preset}().
+    It is possible to apply new equalizer settings to a media player whether the media
+    player is currently playing media or not.
+    Invoking this method will immediately apply the new equalizer settings to the audio
+    output of the currently playing media if there is any.
+    If there is no currently playing media, the new equalizer settings will be applied
+    later if and when new media is played.
+    Equalizer settings will automatically be applied to subsequently played media.
+    To disable the equalizer for a media player invoke this method passing None for the
+    p_equalizer parameter.
+    The media player does not keep a reference to the supplied equalizer so it is safe
+    for an application to release the equalizer reference any time after this method
+    returns.
+    @param p_mi: opaque media player handle.
+    @param p_equalizer: opaque equalizer handle, or None to disable the equalizer for this media player.
+    @return: zero on success, -1 on error.
+    @version: LibVLC 2.2.0 or later.
+    '''
+    f = _Cfunctions.get('libvlc_media_player_set_equalizer', None) or \
+        _Cfunction('libvlc_media_player_set_equalizer', ((1,), (1,),), None,
+                    ctypes.c_int, MediaPlayer, ctypes.c_void_p)
+    return f(p_mi, p_equalizer)
 
 def libvlc_vlm_release(p_instance):
     '''Release the vlm instance related to the given L{Instance}.
@@ -5751,7 +6736,7 @@ def libvlc_vlm_show_media(p_instance, psz_name):
     vlm_media_t though.
     @param p_instance: the instance.
     @param psz_name: the name of the media, if the name is an empty string, all media is described.
-    @return: string with information about named media, or NULL on error.
+    @return: string with information about named media, or None on error.
     '''
     f = _Cfunctions.get('libvlc_vlm_show_media', None) or \
         _Cfunction('libvlc_vlm_show_media', ((1,), (1,),), string_result,
@@ -5863,9 +6848,21 @@ def libvlc_vlm_get_event_manager(p_instance):
 #  libvlc_printerr
 #  libvlc_set_exit_handler
 
-# 17 function(s) not wrapped as methods:
+# 31 function(s) not wrapped as methods:
+#  libvlc_audio_equalizer_get_amp_at_index
+#  libvlc_audio_equalizer_get_band_count
+#  libvlc_audio_equalizer_get_band_frequency
+#  libvlc_audio_equalizer_get_preamp
+#  libvlc_audio_equalizer_get_preset_count
+#  libvlc_audio_equalizer_get_preset_name
+#  libvlc_audio_equalizer_new
+#  libvlc_audio_equalizer_new_from_preset
+#  libvlc_audio_equalizer_release
+#  libvlc_audio_equalizer_set_amp_at_index
+#  libvlc_audio_equalizer_set_preamp
 #  libvlc_audio_output_device_list_release
 #  libvlc_audio_output_list_release
+#  libvlc_chapter_descriptions_release
 #  libvlc_clearerr
 #  libvlc_clock
 #  libvlc_errmsg
@@ -5876,9 +6873,11 @@ def libvlc_vlm_get_event_manager(p_instance):
 #  libvlc_get_version
 #  libvlc_log_get_context
 #  libvlc_log_get_object
+#  libvlc_media_get_codec_description
 #  libvlc_media_tracks_release
 #  libvlc_module_description_list_release
 #  libvlc_new
+#  libvlc_title_descriptions_release
 #  libvlc_track_description_list_release
 #  libvlc_vprinterr
 


### PR DESCRIPTION
Hello,

I present to you two improvements that I made to Beats. One of the two improvements is equalizer support for LibVLC 2.2.0 or newer. In the web interface, if Beats is using a compatible version of LibVLC, he or she should see a button to the left of the volume control containing a gears icon that opens a dialog showing the equalizer controls when clicked. (Of course, if the user is not logged in and the user clicks the button, a login prompt will appear.)

The other improvement is a modified (psuedo-)random sampler to help prevent Beats from playing the same song back-to-back. In the beats.cfg.sample file, you will see two new settings: 'dont_repeat_for' and 'max_dont_repeat_for'. The setting value for 'max_dont_repeat_for' is a non-negative integer representing the maximum number of most recently played songs to prevent Beats from playing back. The setting value for 'dont_repeat_for' is a real number greater than or equal to 0 and less than 1 representing a fraction (or percentage) of the total number of songs in the database, which is the number of songs to prevent Beats from playing back, provided that number doesn't exceed 'max_dont_repeat_for'. Both settings are optional, so Beats will run even with one or both of these settings omitted from the config file. If 'max_dont_repeat_for' is omitted, then there is no restriction on 'dont_repeat_for'. The default setting value for 'dont_repeat_for' is 0, so if 'dont_repeat_for' is omitted, then songs are (psuedo-)randomly selected like how they are now.