### PR TITLE
Improved playback shuffle

### DIFF
--- a/beats.cfg.sample
+++ b/beats.cfg.sample
@@ -1,5 +1,7 @@
 [Player]
 player_name = 1104
+dont_repeat_for = 0.5
+max_dont_repeat_for = 100
 
 [Authentication]
 enabled = true

--- a/scheduler.py
+++ b/scheduler.py
@@ -54,7 +54,7 @@ class Scheduler(object):
 
         if dont_repeat_for > 0: # An optimization
             self.discard_pile.append(song_object['path'])
-            if len(self.discard_pile) > dont_repeat_for:
+            while len(self.discard_pile) > dont_repeat_for:
                 self.discard_pile.popleft()
 
     def get_random_song(self):

--- a/scheduler.py
+++ b/scheduler.py
@@ -46,18 +46,21 @@ class Scheduler(object):
         self._update_active_sessions()
         self._update_finish_times()
 
+    def trim_list(self):
+        ideal_list_size = int(DONT_REPEAT_FOR * song.count_num_songs())
+        if MAX_DONT_REPEAT_FOR is not None:
+            ideal_list_size = min(MAX_DONT_REPEAT_FOR, ideal_list_size)
+        while len(self.discard_pile) > ideal_list_size:
+            self.discard_pile.popleft()
+
     def update_discard_list(self, song_object):
         # Solution based on http://stackoverflow.com/questions/5467174
-        dont_repeat_for = int(DONT_REPEAT_FOR * song.count_num_songs())
-        if MAX_DONT_REPEAT_FOR is not None:
-            dont_repeat_for = min(MAX_DONT_REPEAT_FOR, dont_repeat_for)
-
-        if dont_repeat_for > 0: # An optimization
-            self.discard_pile.append(song_object['path'])
-            while len(self.discard_pile) > dont_repeat_for:
-                self.discard_pile.popleft()
+        self.discard_pile.append(song_object['path'])
+        self.trim_list()
 
     def get_random_song(self):
+        # Trim list in case the playlist size was reduced during playback
+        self.trim_list()
         return song.random_song_not_in_list(self.discard_pile)
 
     def vote_song(self, user, song_id=None, video_url=None):

--- a/scheduler.py
+++ b/scheduler.py
@@ -282,6 +282,7 @@ class Scheduler(object):
         return self.get_queue()
 
     def play_next(self, skip=False):
+        random_song = None
         if self.empty():
             random_song = self.get_random_song()
             if len(random_song) == 1:
@@ -305,7 +306,10 @@ class Scheduler(object):
                     return video.dictify()
                 else:
                     next_song = session.query(Song).get(next_packet.song_id)
-                    self.update_discard_pile_with_song(session, next_song.path)
+                    if random_song is not None:
+                        # Song was not randomly chosen, so update discard pile
+                        self.update_discard_pile_with_song(
+                            session, next_song.path)
                     player.play_media(next_song)
                     next_song.history.append(
                         PlayHistory(user=next_packet.user,

--- a/scheduler.py
+++ b/scheduler.py
@@ -306,7 +306,7 @@ class Scheduler(object):
                     return video.dictify()
                 else:
                     next_song = session.query(Song).get(next_packet.song_id)
-                    if random_song is not None:
+                    if random_song is None:
                         # Song was not randomly chosen, so update discard pile
                         self.update_discard_pile_with_song(
                             session, next_song.path)

--- a/song.py
+++ b/song.py
@@ -9,7 +9,7 @@ from mutagen.flac import FLAC
 from mutagen.oggvorbis import OggVorbis
 from mutagen.mp4 import MP4
 from sqlalchemy.sql import select
-from sqlalchemy.sql.expression import not_, or_, func
+from sqlalchemy.sql.expression import or_, func
 
 PLAYER_NAME = config.get('Player', 'player_name')
 ART_DIR = config.get('Artwork', 'art_path')
@@ -170,25 +170,6 @@ def random_songs(limit=20):
     session.commit()
     songs = [song.dictify() for song in res]
     return {'query': '', 'limit': limit, 'results': songs}
-
-
-def count_num_songs():
-    session = Session()
-    res = session.query(func.count(Song.id)).scalar()
-    session.commit()
-    return res
-
-
-def random_song_not_in_list(blacklisted_filenames):
-    if len(blacklisted_filenames) == 0:
-        return random_songs(limit=1)
-    session = Session()
-    res = session.query(Song).order_by(func.rand()).filter(not_(
-        Song.path.in_(blacklisted_filenames)
-    )).limit(1).all()  # Can't use .first() because we may have zero songs!!!
-    session.commit()
-    songs = [song.dictify() for song in res]
-    return {'query': '', 'limit': 1, 'results': songs}
 
 
 def get_albums_for_artist(artist):


### PR DESCRIPTION
I present to you a modified (psuedo-)random sampler to help prevent Beats from playing the same song back-to-back. In the beats.cfg.sample file, you will see two new settings: 'dont_repeat_for' and 'max_dont_repeat_for'. The setting value for 'max_dont_repeat_for' is a non-negative integer representing the maximum number of most recently played songs to prevent Beats from playing back. The setting value for 'dont_repeat_for' is a real number greater than or equal to 0 and less than 1 representing a fraction (or percentage) of the total number of songs in the database, which is the number of songs to prevent Beats from playing back, provided that number doesn't exceed 'max_dont_repeat_for'. Both settings are optional, so Beats will run even with one or both of these settings omitted from the config file. If 'max_dont_repeat_for' is omitted, then there is no restriction on 'dont_repeat_for'. The default setting value for 'dont_repeat_for' is 0, so if 'dont_repeat_for' is omitted, then songs are (psuedo-)randomly selected like how they are now.
