### PR TITLE
Fix filename to MRL conversion

### DIFF
--- a/db.py
+++ b/db.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import sessionmaker, relationship
 from config import config
 import art
 import datetime
+import urllib
 
 DATABASE_URL = config.get('Database', 'url')
 
@@ -35,7 +36,7 @@ class Song(Base):
                            passive_deletes=True, backref='songs')
 
     def mrl(self):
-        return 'file://' + self.path
+        return 'file://' + urllib.quote(self.path)
 
     def dictify(self):
         return {


### PR DESCRIPTION
There is a bug in the database code, where characters in a pathname of a retrieved song entry are not properly quoted when being converted into an MRL for VLC.  Files whose pathnames have special characters like '#' fail to play without this fix.