### PR TITLE
Support unicode filenames in urllib.quote() call

### DIFF
--- a/db.py
+++ b/db.py
@@ -36,7 +36,7 @@ class Song(Base):
                            passive_deletes=True, backref='songs')
 
     def mrl(self):
-        return 'file://' + urllib.quote(self.path)
+        return 'file://' + urllib.quote(self.path.encode('utf-8'))
 
     def dictify(self):
         return {


### PR DESCRIPTION
This update allows unicode filenames to be supported by the urllib.quote() call in db.py.  It also fixes the following bug:  if Beats comes across a song with a filename like "Chris Brown feat. Usher - New Flame (Dave Audé Remix).mp3", urllib.quote() will fail to convert the accented e and cause Beats to crash with a KeyError because the function only understands valid UTF-8 characters.  Here was the traceback I encountered while I was testing it out:

failed to convert both arguments to Unicode - interpreting them as being unequal
  return ''.join(map(quoter, s))
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "scheduler.py", line 387, in _scheduler_thread
    self.play_next()
  File "scheduler.py", line 313, in play_next
    player.play_media(next_song)
  File "player.py", line 67, in play_media
    play(media.mrl())
  File "db.py", line 39, in mrl
    return 'file://' + urllib.quote(self.path)
  File "/usr/lib/python2.7/urllib.py", line 1288, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xe9'